### PR TITLE
ci: add coverage reporting with 100% threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,6 @@ jobs:
 
       - run: pnpm typecheck
 
-      - run: pnpm test
+      - run: pnpm vitest run --coverage
 
       - run: pnpm build

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,12 @@ export default defineConfig({
 				"src/stores/cloudflare-kv.ts",
 				"src/stores/cloudflare-d1.ts",
 			],
+			thresholds: {
+				statements: 100,
+				branches: 100,
+				functions: 100,
+				lines: 100,
+			},
 		},
 	},
 });


### PR DESCRIPTION
## Summary
- Replace `pnpm test` with `pnpm vitest run --coverage` in CI
- Add coverage thresholds (100% for statements, branches, functions, lines)
- CI will fail if any PR drops coverage below 100%

## Test plan
- [x] `pnpm vitest run --coverage` — 56 tests, 100% coverage
- [x] `pnpm lint` — clean

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)