### PR TITLE
feat: implement Cloudflare KV store

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,28 @@ const store = memoryStore({
 });
 ```
 
+### Cloudflare KV Store
+
+For Cloudflare Workers with KV. TTL is handled automatically by KV expiration.
+
+```ts
+import { kvStore } from "hono-idempotency/stores/cloudflare-kv";
+
+type Bindings = { IDEMPOTENCY_KV: KVNamespace };
+
+const app = new Hono<{ Bindings: Bindings }>();
+
+app.use("/api/*", async (c, next) => {
+  const store = kvStore({
+    namespace: c.env.IDEMPOTENCY_KV,
+    ttl: 86400, // 24 hours in seconds (default)
+  });
+  return idempotency({ store })(c, next);
+});
+```
+
+> **Note:** KV is eventually consistent. In rare cases, concurrent requests to different edge locations may both acquire the lock. This is acceptable for most idempotency use cases.
+
 ### Custom Store
 
 Implement the `IdempotencyStore` interface:

--- a/src/stores/cloudflare-kv.ts
+++ b/src/stores/cloudflare-kv.ts
@@ -1,11 +1,50 @@
+import type { IdempotencyRecord, StoredResponse } from "../types.js";
 import type { IdempotencyStore } from "./types.js";
 
-interface KVStoreOptions {
-	binding: string;
+const DEFAULT_TTL = 86400; // 24 hours in seconds
+
+/** Minimal KVNamespace subset used by kvStore (avoids @cloudflare/workers-types dependency). */
+export interface KVNamespaceLike {
+	get(key: string, options: { type: "json" }): Promise<unknown>;
+	put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
+	delete(key: string): Promise<void>;
+}
+
+export interface KVStoreOptions {
+	/** Cloudflare Workers KV namespace binding. */
+	namespace: KVNamespaceLike;
+	/** TTL in seconds (default: 86400 = 24h). KV minimum is 60 seconds. */
 	ttl?: number;
 }
 
-// Phase 2: Cloudflare KV store implementation
-export function kvStore(_options: KVStoreOptions): IdempotencyStore {
-	throw new Error("cloudflare-kv store is not yet implemented. Coming in Phase 2.");
+export function kvStore(options: KVStoreOptions): IdempotencyStore {
+	const { namespace: kv, ttl = DEFAULT_TTL } = options;
+
+	return {
+		async get(key) {
+			const record = (await kv.get(key, { type: "json" })) as IdempotencyRecord | null;
+			return record ?? undefined;
+		},
+
+		async lock(key, record) {
+			const existing = (await kv.get(key, { type: "json" })) as IdempotencyRecord | null;
+			if (existing) {
+				return false;
+			}
+			await kv.put(key, JSON.stringify(record), { expirationTtl: ttl });
+			return true;
+		},
+
+		async complete(key, response) {
+			const record = (await kv.get(key, { type: "json" })) as IdempotencyRecord | null;
+			if (!record) return;
+			record.status = "completed";
+			record.response = response;
+			await kv.put(key, JSON.stringify(record), { expirationTtl: ttl });
+		},
+
+		async delete(key) {
+			await kv.delete(key);
+		},
+	};
 }

--- a/tests/stores/cloudflare-kv.test.ts
+++ b/tests/stores/cloudflare-kv.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { kvStore } from "../../src/stores/cloudflare-kv.js";
+import type { IdempotencyRecord, StoredResponse } from "../../src/types.js";
+
+/**
+ * Minimal KVNamespace mock that stores data in a Map.
+ * Only implements the subset used by kvStore.
+ */
+function createMockKV(): KVNamespaceMock {
+	const data = new Map<string, string>();
+	return {
+		data,
+		async get(key: string, opts?: { type?: string }) {
+			const value = data.get(key);
+			if (value === undefined) return null;
+			if (opts?.type === "json") return JSON.parse(value);
+			return value;
+		},
+		async put(key: string, value: string, _opts?: { expirationTtl?: number }) {
+			data.set(key, value);
+		},
+		async delete(key: string) {
+			data.delete(key);
+		},
+	};
+}
+
+interface KVNamespaceMock {
+	data: Map<string, string>;
+	get(key: string, opts?: { type?: string }): Promise<unknown>;
+	put(key: string, value: string, opts?: { expirationTtl?: number }): Promise<void>;
+	delete(key: string): Promise<void>;
+}
+
+const makeRecord = (key: string, fingerprint = "fp-abc"): IdempotencyRecord => ({
+	key,
+	fingerprint,
+	status: "processing",
+	createdAt: Date.now(),
+});
+
+const makeResponse = (): StoredResponse => ({
+	status: 200,
+	headers: { "content-type": "application/json" },
+	body: '{"ok":true}',
+});
+
+describe("kvStore", () => {
+	it("lock() returns true and saves the record when key does not exist", async () => {
+		const kv = createMockKV();
+		const store = kvStore({ namespace: kv as never });
+		const record = makeRecord("key-1");
+
+		const result = await store.lock("key-1", record);
+		expect(result).toBe(true);
+
+		const saved = await store.get("key-1");
+		expect(saved).toEqual(record);
+	});
+
+	it("lock() returns false when key already exists", async () => {
+		const kv = createMockKV();
+		const store = kvStore({ namespace: kv as never });
+		const original = makeRecord("key-1", "fp-original");
+		const duplicate = makeRecord("key-1", "fp-duplicate");
+
+		await store.lock("key-1", original);
+		const result = await store.lock("key-1", duplicate);
+
+		expect(result).toBe(false);
+		const saved = await store.get("key-1");
+		expect(saved?.fingerprint).toBe("fp-original");
+	});
+
+	it("complete() updates record to completed with response", async () => {
+		const kv = createMockKV();
+		const store = kvStore({ namespace: kv as never });
+		const record = makeRecord("key-1");
+		const response = makeResponse();
+
+		await store.lock("key-1", record);
+		await store.complete("key-1", response);
+
+		const saved = await store.get("key-1");
+		expect(saved?.status).toBe("completed");
+		expect(saved?.response).toEqual(response);
+	});
+
+	it("get() returns undefined for non-existent key", async () => {
+		const kv = createMockKV();
+		const store = kvStore({ namespace: kv as never });
+
+		expect(await store.get("nonexistent")).toBeUndefined();
+	});
+
+	it("delete() removes the record", async () => {
+		const kv = createMockKV();
+		const store = kvStore({ namespace: kv as never });
+		const record = makeRecord("key-1");
+
+		await store.lock("key-1", record);
+		expect(await store.get("key-1")).toBeDefined();
+
+		await store.delete("key-1");
+		expect(await store.get("key-1")).toBeUndefined();
+	});
+
+	it("passes expirationTtl to KV put()", async () => {
+		const kv = createMockKV();
+		let capturedOpts: { expirationTtl?: number } | undefined;
+		const originalPut = kv.put.bind(kv);
+		kv.put = async (key: string, value: string, opts?: { expirationTtl?: number }) => {
+			capturedOpts = opts;
+			return originalPut(key, value, opts);
+		};
+
+		const store = kvStore({ namespace: kv as never, ttl: 3600 });
+		await store.lock("key-1", makeRecord("key-1"));
+
+		expect(capturedOpts?.expirationTtl).toBe(3600);
+	});
+
+	it("uses default TTL of 86400 seconds (24 hours)", async () => {
+		const kv = createMockKV();
+		let capturedOpts: { expirationTtl?: number } | undefined;
+		const originalPut = kv.put.bind(kv);
+		kv.put = async (key: string, value: string, opts?: { expirationTtl?: number }) => {
+			capturedOpts = opts;
+			return originalPut(key, value, opts);
+		};
+
+		const store = kvStore({ namespace: kv as never });
+		await store.lock("key-1", makeRecord("key-1"));
+
+		expect(capturedOpts?.expirationTtl).toBe(86400);
+	});
+
+	it("complete() does nothing for non-existent key", async () => {
+		const kv = createMockKV();
+		const store = kvStore({ namespace: kv as never });
+
+		// Should not throw
+		await store.complete("nonexistent", makeResponse());
+		expect(await store.get("nonexistent")).toBeUndefined();
+	});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
 				"src/index.ts",
 				"src/types.ts",
 				"src/stores/types.ts",
-				"src/stores/cloudflare-kv.ts",
 				"src/stores/cloudflare-d1.ts",
 			],
 			thresholds: {


### PR DESCRIPTION
## Summary
- Replace KV stub with production-ready implementation using `KVNamespace` binding
- Automatic TTL via KV `expirationTtl` (default 24h, configurable)
- Minimal `KVNamespaceLike` interface avoids `@cloudflare/workers-types` dependency
- Include KV store in coverage (removed from exclude list)
- Add KV store documentation to README

## Test plan
- [x] `pnpm vitest run --coverage` — 64 tests, 100% coverage
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — builds successfully

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)