### PR TITLE
feat: implement Cloudflare D1 store

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,28 @@ app.use("/api/*", async (c, next) => {
 
 > **Note:** KV is eventually consistent. In rare cases, concurrent requests to different edge locations may both acquire the lock. This is acceptable for most idempotency use cases.
 
+### Cloudflare D1 Store
+
+For Cloudflare Workers with D1. Uses SQL for strong consistency. Table is created automatically.
+
+```ts
+import { d1Store } from "hono-idempotency/stores/cloudflare-d1";
+
+type Bindings = { IDEMPOTENCY_DB: D1Database };
+
+const app = new Hono<{ Bindings: Bindings }>();
+
+app.use("/api/*", async (c, next) => {
+  const store = d1Store({
+    database: c.env.IDEMPOTENCY_DB,
+    tableName: "idempotency_keys", // default
+  });
+  return idempotency({ store })(c, next);
+});
+```
+
+> **Note:** D1 provides strong consistency, making `lock()` reliable for concurrent request protection. Consider adding a scheduled cleanup for expired rows.
+
 ### Custom Store
 
 Implement the `IdempotencyStore` interface:

--- a/src/stores/cloudflare-d1.ts
+++ b/src/stores/cloudflare-d1.ts
@@ -1,11 +1,84 @@
+import type { IdempotencyRecord, StoredResponse } from "../types.js";
 import type { IdempotencyStore } from "./types.js";
 
-interface D1StoreOptions {
-	binding: string;
+const DEFAULT_TABLE = "idempotency_keys";
+
+/** Minimal D1Database subset used by d1Store (avoids @cloudflare/workers-types dependency). */
+export interface D1DatabaseLike {
+	prepare(sql: string): D1PreparedStatementLike;
+}
+
+export interface D1PreparedStatementLike {
+	bind(...params: unknown[]): D1PreparedStatementLike;
+	run(): Promise<{ success: boolean; meta: { changes: number } }>;
+	first(): Promise<Record<string, unknown> | null>;
+}
+
+export interface D1StoreOptions {
+	/** Cloudflare D1 database binding. */
+	database: D1DatabaseLike;
+	/** Table name (default: "idempotency_keys"). */
 	tableName?: string;
 }
 
-// Phase 2: Cloudflare D1 store implementation
-export function d1Store(_options: D1StoreOptions): IdempotencyStore {
-	throw new Error("cloudflare-d1 store is not yet implemented. Coming in Phase 2.");
+export function d1Store(options: D1StoreOptions): IdempotencyStore {
+	const { database: db, tableName = DEFAULT_TABLE } = options;
+	let initialized = false;
+
+	const ensureTable = async (): Promise<void> => {
+		if (initialized) return;
+		await db
+			.prepare(
+				`CREATE TABLE IF NOT EXISTS ${tableName} (
+				key TEXT PRIMARY KEY,
+				fingerprint TEXT NOT NULL,
+				status TEXT NOT NULL,
+				response TEXT,
+				created_at INTEGER NOT NULL
+			)`,
+			)
+			.run();
+		initialized = true;
+	};
+
+	const toRecord = (row: Record<string, unknown>): IdempotencyRecord => ({
+		key: row.key as string,
+		fingerprint: row.fingerprint as string,
+		status: row.status as "processing" | "completed",
+		response: row.response ? (JSON.parse(row.response as string) as StoredResponse) : undefined,
+		createdAt: row.created_at as number,
+	});
+
+	return {
+		async get(key) {
+			await ensureTable();
+			const row = await db.prepare(`SELECT * FROM ${tableName} WHERE key = ?`).bind(key).first();
+			if (!row) return undefined;
+			return toRecord(row);
+		},
+
+		async lock(key, record) {
+			await ensureTable();
+			const result = await db
+				.prepare(
+					`INSERT OR IGNORE INTO ${tableName} (key, fingerprint, status, response, created_at) VALUES (?, ?, ?, ?, ?)`,
+				)
+				.bind(key, record.fingerprint, record.status, null, record.createdAt)
+				.run();
+			return result.meta.changes > 0;
+		},
+
+		async complete(key, response) {
+			await ensureTable();
+			await db
+				.prepare(`UPDATE ${tableName} SET status = ?, response = ? WHERE key = ?`)
+				.bind("completed", JSON.stringify(response), key)
+				.run();
+		},
+
+		async delete(key) {
+			await ensureTable();
+			await db.prepare(`DELETE FROM ${tableName} WHERE key = ?`).bind(key).run();
+		},
+	};
 }

--- a/tests/stores/cloudflare-d1.test.ts
+++ b/tests/stores/cloudflare-d1.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import { d1Store } from "../../src/stores/cloudflare-d1.js";
+import type { IdempotencyRecord, StoredResponse } from "../../src/types.js";
+
+/**
+ * Minimal D1Database mock that uses a Map to simulate SQL storage.
+ * Implements the subset of D1 API used by d1Store.
+ */
+function createMockD1(): D1DatabaseMock {
+	const rows = new Map<string, Record<string, unknown>>();
+
+	function createStatement(sql: string) {
+		let boundParams: unknown[] = [];
+
+		const stmt = {
+			bind(...params: unknown[]) {
+				boundParams = params;
+				return stmt;
+			},
+			async run() {
+				if (sql.startsWith("CREATE TABLE")) {
+					return { success: true, meta: { changes: 0 } };
+				}
+				if (sql.startsWith("INSERT OR IGNORE")) {
+					const key = boundParams[0] as string;
+					if (rows.has(key)) {
+						return { success: true, meta: { changes: 0 } };
+					}
+					rows.set(key, {
+						key,
+						fingerprint: boundParams[1],
+						status: boundParams[2],
+						response: boundParams[3],
+						created_at: boundParams[4],
+					});
+					return { success: true, meta: { changes: 1 } };
+				}
+				if (sql.startsWith("UPDATE")) {
+					const key = boundParams[2] as string;
+					const row = rows.get(key);
+					if (row) {
+						row.status = boundParams[0];
+						row.response = boundParams[1];
+					}
+					return { success: true, meta: { changes: row ? 1 : 0 } };
+				}
+				if (sql.startsWith("DELETE")) {
+					const key = boundParams[0] as string;
+					rows.delete(key);
+					return { success: true, meta: { changes: 1 } };
+				}
+				return { success: true, meta: { changes: 0 } };
+			},
+			async first() {
+				if (sql.startsWith("SELECT")) {
+					const key = boundParams[0] as string;
+					const row = rows.get(key);
+					return row ?? null;
+				}
+				return null;
+			},
+		};
+		return stmt;
+	}
+
+	return {
+		rows,
+		prepare: (sql: string) => createStatement(sql),
+	};
+}
+
+interface D1DatabaseMock {
+	rows: Map<string, Record<string, unknown>>;
+	prepare(sql: string): {
+		bind(...params: unknown[]): {
+			run(): Promise<{ success: boolean; meta: { changes: number } }>;
+			first(): Promise<Record<string, unknown> | null>;
+		};
+		run(): Promise<{ success: boolean; meta: { changes: number } }>;
+		first(): Promise<Record<string, unknown> | null>;
+	};
+}
+
+const makeRecord = (key: string, fingerprint = "fp-abc"): IdempotencyRecord => ({
+	key,
+	fingerprint,
+	status: "processing",
+	createdAt: Date.now(),
+});
+
+const makeResponse = (): StoredResponse => ({
+	status: 200,
+	headers: { "content-type": "application/json" },
+	body: '{"ok":true}',
+});
+
+describe("d1Store", () => {
+	it("lock() returns true and saves the record when key does not exist", async () => {
+		const db = createMockD1();
+		const store = d1Store({ database: db as never });
+		const record = makeRecord("key-1");
+
+		const result = await store.lock("key-1", record);
+		expect(result).toBe(true);
+
+		const saved = await store.get("key-1");
+		expect(saved?.key).toBe("key-1");
+		expect(saved?.fingerprint).toBe("fp-abc");
+		expect(saved?.status).toBe("processing");
+	});
+
+	it("lock() returns false when key already exists", async () => {
+		const db = createMockD1();
+		const store = d1Store({ database: db as never });
+		const original = makeRecord("key-1", "fp-original");
+		const duplicate = makeRecord("key-1", "fp-duplicate");
+
+		await store.lock("key-1", original);
+		const result = await store.lock("key-1", duplicate);
+
+		expect(result).toBe(false);
+		const saved = await store.get("key-1");
+		expect(saved?.fingerprint).toBe("fp-original");
+	});
+
+	it("complete() updates record to completed with response", async () => {
+		const db = createMockD1();
+		const store = d1Store({ database: db as never });
+		const record = makeRecord("key-1");
+		const response = makeResponse();
+
+		await store.lock("key-1", record);
+		await store.complete("key-1", response);
+
+		const saved = await store.get("key-1");
+		expect(saved?.status).toBe("completed");
+		expect(saved?.response).toEqual(response);
+	});
+
+	it("get() returns undefined for non-existent key", async () => {
+		const db = createMockD1();
+		const store = d1Store({ database: db as never });
+
+		expect(await store.get("nonexistent")).toBeUndefined();
+	});
+
+	it("delete() removes the record", async () => {
+		const db = createMockD1();
+		const store = d1Store({ database: db as never });
+		const record = makeRecord("key-1");
+
+		await store.lock("key-1", record);
+		expect(await store.get("key-1")).toBeDefined();
+
+		await store.delete("key-1");
+		expect(await store.get("key-1")).toBeUndefined();
+	});
+
+	it("complete() does nothing for non-existent key", async () => {
+		const db = createMockD1();
+		const store = d1Store({ database: db as never });
+
+		await store.complete("nonexistent", makeResponse());
+		expect(await store.get("nonexistent")).toBeUndefined();
+	});
+
+	it("uses custom table name", async () => {
+		const db = createMockD1();
+		const store = d1Store({ database: db as never, tableName: "custom_table" });
+		const record = makeRecord("key-1");
+
+		const result = await store.lock("key-1", record);
+		expect(result).toBe(true);
+
+		const saved = await store.get("key-1");
+		expect(saved?.key).toBe("key-1");
+	});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,12 +6,7 @@ export default defineConfig({
 		coverage: {
 			provider: "v8",
 			include: ["src/**/*.ts"],
-			exclude: [
-				"src/index.ts",
-				"src/types.ts",
-				"src/stores/types.ts",
-				"src/stores/cloudflare-d1.ts",
-			],
+			exclude: ["src/index.ts", "src/types.ts", "src/stores/types.ts"],
 			thresholds: {
 				statements: 100,
 				branches: 100,


### PR DESCRIPTION
## Summary
- Replace D1 stub with production-ready implementation using SQL
- `INSERT OR IGNORE` for atomic lock (strong consistency, unlike KV)
- Auto-creates `idempotency_keys` table (configurable name)
- 7 new tests, 100% coverage maintained (71 total)
- Add D1 store documentation to README
- Remove D1 from coverage exclude list

## Test plan
- [x] `pnpm vitest run --coverage` — 71 tests, 100% coverage
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)