### PR TITLE
chore: add changeset for v0.2.0

### DIFF
--- a/.changeset/release-0.2.0.md
+++ b/.changeset/release-0.2.0.md
@@ -1,0 +1,5 @@
+---
+"hono-idempotency": minor
+---
+
+Add Cloudflare KV and D1 store implementations, memory store GC, CI coverage enforcement


### PR DESCRIPTION
## Summary
Changeset for minor version bump (0.1.1 → 0.2.0):
- Cloudflare KV store implementation
- Cloudflare D1 store implementation
- Memory store periodic sweep (GC)
- CI coverage enforcement (100% threshold)
- Custom `headerName` test coverage
- README docs for `skipRequest`, `cacheKeyPrefix`, `onError`, KV/D1 stores

Merging this will trigger the release workflow to create a Version PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)