### PR TITLE
fix: improve type safety, exports, tests, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ Stripe-style Idempotency-Key middleware for [Hono](https://hono.dev). IETF [draf
 ## Install
 
 ```bash
+# npm
 npm install hono-idempotency
+
+# pnpm
+pnpm add hono-idempotency
 ```
 
 ## Quick Start
@@ -145,6 +149,7 @@ type Bindings = { IDEMPOTENCY_KV: KVNamespace };
 
 const app = new Hono<{ Bindings: Bindings }>();
 
+// Store must be created per-request since KV binding comes from c.env
 app.use("/api/*", async (c, next) => {
   const store = kvStore({
     namespace: c.env.IDEMPOTENCY_KV,
@@ -167,10 +172,13 @@ type Bindings = { IDEMPOTENCY_DB: D1Database };
 
 const app = new Hono<{ Bindings: Bindings }>();
 
+// Store must be created per-request since D1 binding comes from c.env.
+// CREATE TABLE IF NOT EXISTS runs each request but is a no-op after the first.
 app.use("/api/*", async (c, next) => {
   const store = d1Store({
     database: c.env.IDEMPOTENCY_DB,
     tableName: "idempotency_keys", // default
+    ttl: 86400, // 24 hours in seconds (default)
   });
   return idempotency({ store })(c, next);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export type {
 } from "./types.js";
 export type { IdempotencyStore } from "./stores/types.js";
 export type { ProblemDetail } from "./errors.js";
+export type { MemoryStore } from "./stores/memory.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ import type { IdempotencyStore } from "./stores/types.js";
 
 export interface IdempotencyEnv extends Env {
 	Variables: {
-		idempotencyKey: string;
+		idempotencyKey: string | undefined;
 	};
 }
 


### PR DESCRIPTION
## Summary

- `IdempotencyEnv.Variables.idempotencyKey` type changed from `string` to `string | undefined` — the middleware only calls `c.set()` after lock, so it's undefined when method is excluded or key is absent
- Export `MemoryStore` type from root entry point (`hono-idempotency`)
- Add test: `onError` callback receives Hono context with request info
- Add test: `cacheKeyPrefix` with special characters (`org:acme/team:1`) exercises `encodeURIComponent`
- README: add `pnpm add` install command alongside npm
- README: clarify KV/D1 per-request store creation pattern with comments

## Test plan

- [x] All 77 tests pass
- [x] 100% coverage maintained
- [x] Type check clean
- [x] Biome lint clean

Closes #23, closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)