### PR TITLE
feat: add store.purge(), error codes, and docs improvements

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,8 +1,15 @@
+export type IdempotencyErrorCode =
+	| "MISSING_KEY"
+	| "KEY_TOO_LONG"
+	| "FINGERPRINT_MISMATCH"
+	| "CONFLICT";
+
 export interface ProblemDetail {
 	type: string;
 	title: string;
 	status: number;
 	detail: string;
+	code: IdempotencyErrorCode;
 }
 
 export function problemResponse(
@@ -27,6 +34,7 @@ export const IdempotencyErrors = {
 			title: "Idempotency-Key header is required",
 			status: 400,
 			detail: "This endpoint requires an Idempotency-Key header",
+			code: "MISSING_KEY",
 		};
 	},
 
@@ -36,6 +44,7 @@ export const IdempotencyErrors = {
 			title: "Idempotency-Key is too long",
 			status: 400,
 			detail: `Idempotency-Key must be at most ${maxLength} characters`,
+			code: "KEY_TOO_LONG",
 		};
 	},
 
@@ -46,6 +55,7 @@ export const IdempotencyErrors = {
 			status: 422,
 			detail:
 				"A request with the same idempotency key but different parameters was already processed",
+			code: "FINGERPRINT_MISMATCH",
 		};
 	},
 
@@ -55,6 +65,7 @@ export const IdempotencyErrors = {
 			title: "A request is outstanding for this idempotency key",
 			status: 409,
 			detail: "A request with the same idempotency key is currently being processed",
+			code: "CONFLICT",
 		};
 	},
 } as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,5 @@ export type {
 	StoredResponse,
 } from "./types.js";
 export type { IdempotencyStore } from "./stores/types.js";
-export type { ProblemDetail } from "./errors.js";
+export type { IdempotencyErrorCode, ProblemDetail } from "./errors.js";
 export type { MemoryStore } from "./stores/memory.js";

--- a/src/stores/cloudflare-d1.ts
+++ b/src/stores/cloudflare-d1.ts
@@ -98,5 +98,14 @@ export function d1Store(options: D1StoreOptions): IdempotencyStore {
 			await ensureTable();
 			await db.prepare(`DELETE FROM ${tableName} WHERE key = ?`).bind(key).run();
 		},
+
+		async purge() {
+			await ensureTable();
+			const result = await db
+				.prepare(`DELETE FROM ${tableName} WHERE created_at < ?`)
+				.bind(ttlThreshold())
+				.run();
+			return result.meta.changes;
+		},
 	};
 }

--- a/src/stores/cloudflare-kv.ts
+++ b/src/stores/cloudflare-kv.ts
@@ -46,5 +46,10 @@ export function kvStore(options: KVStoreOptions): IdempotencyStore {
 		async delete(key) {
 			await kv.delete(key);
 		},
+
+		async purge() {
+			// KV handles expiration automatically via expirationTtl — no manual purge needed
+			return 0;
+		},
 	};
 }

--- a/src/stores/memory.ts
+++ b/src/stores/memory.ts
@@ -73,5 +73,16 @@ export function memoryStore(options: MemoryStoreOptions = {}): MemoryStore {
 		async delete(key) {
 			map.delete(key);
 		},
+
+		async purge() {
+			let count = 0;
+			for (const [key, record] of map) {
+				if (isExpired(record)) {
+					map.delete(key);
+					count++;
+				}
+			}
+			return count;
+		},
 	};
 }

--- a/src/stores/types.ts
+++ b/src/stores/types.ts
@@ -15,4 +15,7 @@ export interface IdempotencyStore {
 
 	/** Delete a key (cleanup on error). */
 	delete(key: string): Promise<void>;
+
+	/** Physically remove expired records. Returns the number of purged entries. */
+	purge(): Promise<number>;
 }

--- a/tests/stores/cloudflare-kv.test.ts
+++ b/tests/stores/cloudflare-kv.test.ts
@@ -135,6 +135,15 @@ describe("kvStore", () => {
 		expect(capturedOpts?.expirationTtl).toBe(86400);
 	});
 
+	it("purge() returns 0 (KV handles expiration automatically)", async () => {
+		const kv = createMockKV();
+		const store = kvStore({ namespace: kv as never });
+
+		await store.lock("key-1", makeRecord("key-1"));
+		const purged = await store.purge();
+		expect(purged).toBe(0);
+	});
+
 	it("complete() does nothing for non-existent key", async () => {
 		const kv = createMockKV();
 		const store = kvStore({ namespace: kv as never });


### PR DESCRIPTION
## Summary

### 1. `store.purge()` — Physical deletion of expired records
- Added `purge(): Promise<number>` to `IdempotencyStore` interface
- **D1**: `DELETE FROM table WHERE created_at < ?` — critical for D1's 5GB storage limit
- **Memory**: Sweep expired entries and return count
- **KV**: No-op (KV handles expiration automatically via `expirationTtl`)
- README documents usage with `waitUntil` and scheduled workers

### 2. Error codes on `ProblemDetail`
- Added `code` field: `MISSING_KEY | KEY_TOO_LONG | FINGERPRINT_MISMATCH | CONFLICT`
- Enables programmatic error identification without relying on URL strings
- Exported `IdempotencyErrorCode` type from root

### 3. Documentation
- Error code table in onError section with example
- Purge usage examples (waitUntil, scheduled worker)
- cacheKeyPrefix Context type cast note

## Test plan

- [x] 87 tests pass (7 new: purge x5, error codes x2)
- [x] 100% coverage maintained
- [x] Type check clean
- [x] Biome lint clean
- [x] Security review passed (parameterized SQL, no info disclosure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)