### PR TITLE
docs: add store selection guide and JSDoc to store interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,19 @@ idempotency({
 
 ## Stores
 
+### Choosing a Store
+
+| | Memory | Cloudflare KV | Cloudflare D1 |
+|---|---|---|---|
+| **Consistency** | Strong (single-instance) | Eventual | Strong |
+| **Durability** | None (process-local) | Durable | Durable |
+| **Lock atomicity** | Atomic (in-process Map) | Not atomic across edge locations | Atomic (SQL INSERT OR IGNORE) |
+| **TTL** | In-process sweep | Automatic (expirationTtl) | SQL filter on created_at |
+| **Setup** | None | KV namespace binding | D1 database binding |
+| **Best for** | Development, single-instance | Multi-region, low-contention | Multi-region, strong consistency |
+
+> **Tip:** Start with `memoryStore()` for development. For production on Cloudflare Workers, use `d1Store` when you need strong consistency guarantees, or `kvStore` for simpler deployments where occasional duplicate processing is acceptable.
+
 ### Memory Store
 
 Built-in, suitable for single-instance deployments and development.

--- a/src/stores/types.ts
+++ b/src/stores/types.ts
@@ -1,21 +1,38 @@
 import type { IdempotencyRecord, StoredResponse } from "../types.js";
 
 export interface IdempotencyStore {
-	/** Get a record by key. Returns undefined if not found. */
+	/**
+	 * Get a record by key. Returns undefined if the key does not exist or has expired.
+	 * Implementations should filter out expired records transparently.
+	 */
 	get(key: string): Promise<IdempotencyRecord | undefined>;
 
 	/**
-	 * Attempt to lock a key (save in "processing" state).
-	 * Returns false if the key already exists (optimistic lock).
+	 * Attempt to lock a key by storing a record in "processing" state.
+	 * Must be atomic: if two concurrent calls race on the same key,
+	 * exactly one must return true and the other false.
+	 * Returns true if the lock was acquired, false if the key already exists.
+	 * Expired keys should be treated as non-existent (lock succeeds).
 	 */
 	lock(key: string, record: IdempotencyRecord): Promise<boolean>;
 
-	/** Save the response and mark the record as "completed". */
+	/**
+	 * Mark a record as "completed" and attach the response.
+	 * Called after the handler returns a 2xx response.
+	 * If the key does not exist, this should be a no-op.
+	 */
 	complete(key: string, response: StoredResponse): Promise<void>;
 
-	/** Delete a key (cleanup on error). */
+	/**
+	 * Delete a record. Called when the handler throws or returns non-2xx.
+	 * Allows the client to retry with the same key.
+	 */
 	delete(key: string): Promise<void>;
 
-	/** Physically remove expired records. Returns the number of purged entries. */
+	/**
+	 * Physically remove expired records and return the count of deleted entries.
+	 * For stores with automatic expiration (e.g., KV with expirationTtl),
+	 * this may be a no-op returning 0.
+	 */
 	purge(): Promise<number>;
 }


### PR DESCRIPTION
## Summary
- Add store comparison table to README (consistency, durability, lock atomicity, TTL, best use case)
- Add detailed JSDoc to `IdempotencyStore` interface methods with atomicity requirements and behavioral contracts

Closes #36

## Test plan
- [x] `pnpm lint` — pass
- [x] `pnpm typecheck` — pass
- [x] `pnpm test` — 87 tests pass
- [ ] Verify README table renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)