### PR TITLE
chore: add Node.js 24 to CI matrix and remove unused vitest globals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
 	test: {
-		globals: true,
 		coverage: {
 			provider: "v8",
 			include: ["src/**/*.ts"],


### PR DESCRIPTION
## Summary
- Add Node.js 24 (LTS since October 2025) to CI test matrix
- Remove unused `globals: true` from vitest config — all test files explicitly import from `vitest`

Closes #38

## Test plan
- [x] `pnpm test` — 87 tests pass locally
- [ ] CI passes on Node 20, 22, and 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)