### PR TITLE
feat: export problemResponse for selective onError customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,23 @@ idempotency({
 });
 ```
 
+Use `problemResponse` as a fallback to keep the default RFC 9457 format for unhandled error codes:
+
+```ts
+import { problemResponse } from "hono-idempotency";
+
+idempotency({
+  store: memoryStore(),
+  onError: (error, c) => {
+    if (error.code === "CONFLICT") {
+      return c.json({ retryAfter: 1 }, 409);
+    }
+    // Default RFC 9457 response for all other errors
+    return problemResponse(error);
+  },
+});
+```
+
 ## Stores
 
 ### Choosing a Store

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { idempotency } from "./middleware.js";
+export { problemResponse } from "./errors.js";
 export type {
 	IdempotencyEnv,
 	IdempotencyOptions,


### PR DESCRIPTION
## Summary
- Export `problemResponse` from package root for use as fallback in `onError` callbacks
- Add test verifying selective `onError` with `problemResponse` fallback (88 tests total)
- Add README example showing the pattern

Closes #40

## Test plan
- [x] `pnpm lint` — pass
- [x] `pnpm typecheck` — pass
- [x] `pnpm test` — 88 tests pass
- [x] `pnpm build` — ESM + CJS + DTS build success

🤖 Generated with [Claude Code](https://claude.com/claude-code)