### PR TITLE
chore: add changeset for v0.5.0

### DIFF
--- a/.changeset/release-v050.md
+++ b/.changeset/release-v050.md
@@ -1,0 +1,5 @@
+---
+"hono-idempotency": minor
+---
+
+Export `problemResponse` for selective `onError` customization, add store selection guide, and improve JSDoc


### PR DESCRIPTION
## Summary
- Add changeset for v0.5.0 release

### Changes since v0.4.0
- **feat**: Export `problemResponse` for selective `onError` customization (#40)
- **docs**: Store selection guide with comparison table (#36)
- **docs**: JSDoc on `IdempotencyStore` interface (#36)
- **chore**: Node.js 24 in CI matrix (#38)

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)