### PR TITLE
chore: add sideEffects false for tree-shaking and update CLAUDE.md to v0.5.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,11 @@
 
 ## Project
 
-Stripe-style Idempotency-Key middleware for Hono (v0.4.0). IETF draft-ietf-httpapi-idempotency-key-header compliant.
+Stripe-style Idempotency-Key middleware for Hono (v0.5.0). IETF draft-ietf-httpapi-idempotency-key-header compliant.
 
 ## Commands
 
-- `pnpm test` — Run tests (vitest, 87 tests across 5 files)
+- `pnpm test` — Run tests (vitest, 88 tests across 5 files)
 - `pnpm build` — Build ESM + CJS (tsup)
 - `pnpm lint` — Check linting (biome)
 - `pnpm lint:fix` — Auto-fix lint issues

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 			}
 		}
 	},
+	"sideEffects": false,
 	"files": ["dist"],
 	"scripts": {
 		"build": "tsup",


### PR DESCRIPTION
## Summary
- Add `"sideEffects": false` to package.json for better tree-shaking in bundlers (webpack, rollup)
- Update CLAUDE.md: v0.4.0 → v0.5.0, 87 → 88 tests

Closes #45

## Test plan
- [x] `pnpm lint` / `pnpm typecheck` / `pnpm test` / `pnpm build` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)