### PR TITLE
fix: export MemoryStoreOptions for API consistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Stripe-style Idempotency-Key middleware for Hono (v0.5.0). IETF draft-ietf-httpa
 
 ## Commands
 
-- `pnpm test` — Run tests (vitest, 88 tests across 5 files)
+- `pnpm test` — Run tests (vitest, 90 tests across 5 files)
 - `pnpm build` — Build ESM + CJS (tsup)
 - `pnpm lint` — Check linting (biome)
 - `pnpm lint:fix` — Auto-fix lint issues

--- a/src/stores/memory.ts
+++ b/src/stores/memory.ts
@@ -3,7 +3,7 @@ import type { IdempotencyStore } from "./types.js";
 
 const DEFAULT_TTL = 24 * 60 * 60 * 1000; // 24 hours
 
-interface MemoryStoreOptions {
+export interface MemoryStoreOptions {
 	ttl?: number;
 	/** Maximum number of entries. Oldest entries are evicted when exceeded. */
 	maxSize?: number;


### PR DESCRIPTION
## Summary
- Export `MemoryStoreOptions` interface from `stores/memory.ts` — `KVStoreOptions` and `D1StoreOptions` were already exported, this was the only missing one
- Update CLAUDE.md test count (88 → 90)

Closes #50

## Test plan
- [x] `pnpm typecheck` — no errors
- [x] `pnpm test` — all 90 tests pass
- [x] `pnpm lint` — no biome errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)