### PR TITLE
chore: add isolatedModules for esbuild compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
 		"strict": true,
 		"esModuleInterop": true,
 		"skipLibCheck": true,
+		"isolatedModules": true,
 		"forceConsistentCasingInFileNames": true,
 		"declaration": true,
 		"declarationMap": true,


### PR DESCRIPTION
## Summary
- Add `isolatedModules: true` to `tsconfig.json`
- tsup uses esbuild which transpiles files individually; this flag ensures TypeScript warns about incompatible patterns (const enums, namespace merges)

Closes #52

## Test plan
- [x] `pnpm typecheck` — no errors
- [x] `pnpm test` — all 90 tests pass
- [x] `pnpm build` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)