### PR TITLE
test: add maxKeyLength exact boundary test

### DIFF
--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -124,6 +124,18 @@ describe("idempotency middleware", () => {
 		expect(body.title).toContain("too long");
 	});
 
+	// Boundary: key exactly at maxKeyLength is accepted
+	it("accepts key of exactly maxKeyLength characters", async () => {
+		const { app } = createApp({ maxKeyLength: 36 });
+		const exactKey = "a".repeat(36);
+
+		const res = await app.request("/api/text", {
+			method: "POST",
+			headers: { "Idempotency-Key": exactKey },
+		});
+		expect(res.status).toBe(200);
+	});
+
 	// E7: concurrent requests → one 200, one 409
 	it("E7: returns 409 Conflict for concurrent requests with same key", async () => {
 		const { app } = createApp();


### PR DESCRIPTION
## Summary
- Add boundary value test: key of exactly `maxKeyLength` characters is accepted
- Complements E6 which tests `maxKeyLength + 1` (rejected)
- Total: 91 tests

Closes #54

## Test plan
- [x] `pnpm test` — all 91 tests pass
- [x] `pnpm lint` — no biome errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)