### PR TITLE
chore: add .editorconfig for contributor consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary
- Add `.editorconfig` matching the Biome configuration
- Ensures consistent formatting (tabs, UTF-8, LF, trailing newlines) for contributors without Biome integration
- Markdown files preserve trailing whitespace (significant in markdown)

Closes #56

## Test plan
- [x] `pnpm lint` — no biome errors
- [x] Settings match biome.json (tab indent, line width conventions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)