### PR TITLE
feat: add observability hooks (onCacheHit, onCacheMiss)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -34,4 +34,16 @@ export interface IdempotencyOptions {
 	/** Return a Response with an error status (4xx/5xx). Returning 2xx bypasses idempotency guarantees. */
 	onError?: (error: ProblemDetail, c: Context) => Response | Promise<Response>;
 	cacheKeyPrefix?: string | ((c: Context) => string | Promise<string>);
+	/**
+	 * Called when a cached response is about to be replayed.
+	 * Errors are swallowed — hooks must not affect request processing.
+	 * `key` is the raw header value; sanitize before logging to prevent log injection.
+	 */
+	onCacheHit?: (key: string, c: Context) => void | Promise<void>;
+	/**
+	 * Called when a new request acquires the lock (before the handler runs).
+	 * Fires on each lock acquisition, including retries after prior failures.
+	 * Errors are swallowed — hooks must not affect request processing.
+	 */
+	onCacheMiss?: (key: string, c: Context) => void | Promise<void>;
 }


### PR DESCRIPTION
## Summary
- Add `onCacheHit` and `onCacheMiss` optional callbacks to `IdempotencyOptions`
- Hook errors are swallowed via `safeHook()` — hooks must not break idempotency guarantees
- JSDoc clarifies that `onCacheMiss` fires per lock acquisition (including retries after failures)
- `onCacheHit` fires only on successful replay (not on 409 conflict or 422 fingerprint mismatch)

## Usage
```ts
idempotency({
  store: memoryStore(),
  onCacheHit: (key, c) => metrics.increment("idempotency.hit"),
  onCacheMiss: (key, c) => metrics.increment("idempotency.miss"),
})
```

Closes #59

## Test plan
- [x] 101 tests pass (10 new hook tests)
- [x] 100% coverage maintained
- [x] `pnpm typecheck` — no errors
- [x] `pnpm lint` — no biome errors
- [x] Code review: addressed all findings
- [x] Security review: addressed all findings (safeHook, JSDoc warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)