### PR TITLE
feat: add Redis store adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,16 @@
 				"types": "./dist/stores/cloudflare-d1.d.cts",
 				"default": "./dist/stores/cloudflare-d1.cjs"
 			}
+		},
+		"./stores/redis": {
+			"import": {
+				"types": "./dist/stores/redis.d.ts",
+				"default": "./dist/stores/redis.js"
+			},
+			"require": {
+				"types": "./dist/stores/redis.d.cts",
+				"default": "./dist/stores/redis.cjs"
+			}
 		}
 	},
 	"sideEffects": false,

--- a/src/stores/redis.ts
+++ b/src/stores/redis.ts
@@ -1,0 +1,53 @@
+import type { IdempotencyRecord, StoredResponse } from "../types.js";
+import type { IdempotencyStore } from "./types.js";
+
+const DEFAULT_TTL = 86400; // 24 hours in seconds
+
+/** Minimal Redis client subset compatible with ioredis, node-redis, and @upstash/redis. */
+export interface RedisClientLike {
+	get(key: string): Promise<string | null>;
+	set(key: string, value: string, options?: { NX?: boolean; EX?: number }): Promise<string | null>;
+	del(...keys: string[]): Promise<number>;
+}
+
+export interface RedisStoreOptions {
+	/** Redis client instance (ioredis, node-redis, or @upstash/redis). */
+	client: RedisClientLike;
+	/** TTL in seconds (default: 86400 = 24h). Passed as Redis EX option. */
+	ttl?: number;
+}
+
+export function redisStore(options: RedisStoreOptions): IdempotencyStore {
+	const { client, ttl = DEFAULT_TTL } = options;
+
+	return {
+		async get(key) {
+			const raw = await client.get(key);
+			if (!raw) return undefined;
+			return JSON.parse(raw) as IdempotencyRecord;
+		},
+
+		async lock(key, record) {
+			const result = await client.set(key, JSON.stringify(record), { NX: true, EX: ttl });
+			return result === "OK";
+		},
+
+		async complete(key, response) {
+			const raw = await client.get(key);
+			if (!raw) return;
+			const record = JSON.parse(raw) as IdempotencyRecord;
+			record.status = "completed";
+			record.response = response;
+			await client.set(key, JSON.stringify(record), { EX: ttl });
+		},
+
+		async delete(key) {
+			await client.del(key);
+		},
+
+		async purge() {
+			// Redis handles expiration automatically via EX — no manual purge needed
+			return 0;
+		},
+	};
+}

--- a/tests/stores/redis.test.ts
+++ b/tests/stores/redis.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { redisStore } from "../../src/stores/redis.js";
+import type { IdempotencyRecord, StoredResponse } from "../../src/types.js";
+
+/**
+ * Mock Redis client backed by a Map with TTL support.
+ * Implements SET NX/EX semantics matching ioredis / node-redis / @upstash/redis.
+ */
+function createMockRedis() {
+	const data = new Map<string, { value: string; expireAt?: number }>();
+	return {
+		data,
+		async get(key: string): Promise<string | null> {
+			const entry = data.get(key);
+			if (!entry) return null;
+			if (entry.expireAt && Date.now() >= entry.expireAt) {
+				data.delete(key);
+				return null;
+			}
+			return entry.value;
+		},
+		async set(
+			key: string,
+			value: string,
+			opts?: { NX?: boolean; EX?: number },
+		): Promise<string | null> {
+			if (opts?.NX) {
+				const existing = data.get(key);
+				if (existing && (!existing.expireAt || Date.now() < existing.expireAt)) {
+					return null;
+				}
+			}
+			data.set(key, {
+				value,
+				expireAt: opts?.EX ? Date.now() + opts.EX * 1000 : undefined,
+			});
+			return "OK";
+		},
+		async del(...keys: string[]): Promise<number> {
+			let count = 0;
+			for (const k of keys) {
+				if (data.delete(k)) count++;
+			}
+			return count;
+		},
+	};
+}
+
+const makeRecord = (key: string, fingerprint = "fp-abc"): IdempotencyRecord => ({
+	key,
+	fingerprint,
+	status: "processing",
+	createdAt: Date.now(),
+});
+
+const makeResponse = (): StoredResponse => ({
+	status: 200,
+	headers: { "content-type": "application/json" },
+	body: '{"ok":true}',
+});
+
+describe("redisStore", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("lock() returns true and saves the record when key does not exist", async () => {
+		const client = createMockRedis();
+		const store = redisStore({ client });
+		const record = makeRecord("key-1");
+
+		const result = await store.lock("key-1", record);
+		expect(result).toBe(true);
+
+		const saved = await store.get("key-1");
+		expect(saved).toEqual(record);
+	});
+
+	it("lock() returns false when key already exists", async () => {
+		const client = createMockRedis();
+		const store = redisStore({ client });
+		const original = makeRecord("key-1", "fp-original");
+		const duplicate = makeRecord("key-1", "fp-duplicate");
+
+		await store.lock("key-1", original);
+		const result = await store.lock("key-1", duplicate);
+
+		expect(result).toBe(false);
+		const saved = await store.get("key-1");
+		expect(saved?.fingerprint).toBe("fp-original");
+	});
+
+	it("get() returns stored record", async () => {
+		const client = createMockRedis();
+		const store = redisStore({ client });
+		const record = makeRecord("key-1");
+
+		await store.lock("key-1", record);
+		const saved = await store.get("key-1");
+		expect(saved).toEqual(record);
+	});
+
+	it("get() returns undefined for non-existent key", async () => {
+		const client = createMockRedis();
+		const store = redisStore({ client });
+
+		expect(await store.get("nonexistent")).toBeUndefined();
+	});
+
+	it("complete() updates status and attaches response", async () => {
+		const client = createMockRedis();
+		const store = redisStore({ client });
+		const record = makeRecord("key-1");
+		const response = makeResponse();
+
+		await store.lock("key-1", record);
+		await store.complete("key-1", response);
+
+		const saved = await store.get("key-1");
+		expect(saved?.status).toBe("completed");
+		expect(saved?.response).toEqual(response);
+	});
+
+	it("complete() on non-existent key is a no-op", async () => {
+		const client = createMockRedis();
+		const store = redisStore({ client });
+
+		await store.complete("nonexistent", makeResponse());
+		expect(await store.get("nonexistent")).toBeUndefined();
+	});
+
+	it("delete() removes record", async () => {
+		const client = createMockRedis();
+		const store = redisStore({ client });
+		const record = makeRecord("key-1");
+
+		await store.lock("key-1", record);
+		expect(await store.get("key-1")).toBeDefined();
+
+		await store.delete("key-1");
+		expect(await store.get("key-1")).toBeUndefined();
+	});
+
+	it("record expires after TTL", async () => {
+		const client = createMockRedis();
+		const store = redisStore({ client, ttl: 60 });
+
+		await store.lock("key-1", makeRecord("key-1"));
+		expect(await store.get("key-1")).toBeDefined();
+
+		vi.advanceTimersByTime(60 * 1000);
+		expect(await store.get("key-1")).toBeUndefined();
+	});
+
+	it("lock() succeeds after TTL expiry (re-acquirable)", async () => {
+		const client = createMockRedis();
+		const store = redisStore({ client, ttl: 60 });
+
+		await store.lock("key-1", makeRecord("key-1", "fp-first"));
+		vi.advanceTimersByTime(60 * 1000);
+
+		const result = await store.lock("key-1", makeRecord("key-1", "fp-second"));
+		expect(result).toBe(true);
+
+		const saved = await store.get("key-1");
+		expect(saved?.fingerprint).toBe("fp-second");
+	});
+
+	it("purge() returns 0 (no-op)", async () => {
+		const client = createMockRedis();
+		const store = redisStore({ client });
+
+		await store.lock("key-1", makeRecord("key-1"));
+		const purged = await store.purge();
+		expect(purged).toBe(0);
+	});
+
+	it("passes custom TTL to Redis EX", async () => {
+		const client = createMockRedis();
+		let capturedOpts: { NX?: boolean; EX?: number } | undefined;
+		const originalSet = client.set.bind(client);
+		client.set = async (key: string, value: string, opts?: { NX?: boolean; EX?: number }) => {
+			capturedOpts = opts;
+			return originalSet(key, value, opts);
+		};
+
+		const store = redisStore({ client, ttl: 3600 });
+		await store.lock("key-1", makeRecord("key-1"));
+
+		expect(capturedOpts?.EX).toBe(3600);
+		expect(capturedOpts?.NX).toBe(true);
+	});
+
+	it("uses default TTL of 86400 seconds (24 hours)", async () => {
+		const client = createMockRedis();
+		let capturedOpts: { NX?: boolean; EX?: number } | undefined;
+		const originalSet = client.set.bind(client);
+		client.set = async (key: string, value: string, opts?: { NX?: boolean; EX?: number }) => {
+			capturedOpts = opts;
+			return originalSet(key, value, opts);
+		};
+
+		const store = redisStore({ client });
+		await store.lock("key-1", makeRecord("key-1"));
+
+		expect(capturedOpts?.EX).toBe(86400);
+	});
+
+	it("complete() preserves TTL on update", async () => {
+		const client = createMockRedis();
+		let capturedOpts: { NX?: boolean; EX?: number } | undefined;
+		const originalSet = client.set.bind(client);
+		client.set = async (key: string, value: string, opts?: { NX?: boolean; EX?: number }) => {
+			capturedOpts = opts;
+			return originalSet(key, value, opts);
+		};
+
+		const store = redisStore({ client, ttl: 3600 });
+		await store.lock("key-1", makeRecord("key-1"));
+		await store.complete("key-1", makeResponse());
+
+		// complete() should set EX but NOT NX (needs to overwrite)
+		expect(capturedOpts?.EX).toBe(3600);
+		expect(capturedOpts?.NX).toBeUndefined();
+	});
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
 		"stores/memory": "src/stores/memory.ts",
 		"stores/cloudflare-kv": "src/stores/cloudflare-kv.ts",
 		"stores/cloudflare-d1": "src/stores/cloudflare-d1.ts",
+		"stores/redis": "src/stores/redis.ts",
 	},
 	format: ["esm", "cjs"],
 	dts: true,


### PR DESCRIPTION
## Summary

- Add `redisStore()` with `RedisClientLike` interface compatible with ioredis, node-redis, and @upstash/redis
- Atomic locking via Redis `SET NX EX` — strongest lock primitive among all store backends
- `purge()` is a no-op (Redis handles expiration automatically via `EX`)
- 13 tests covering core CRUD, TTL expiry, re-acquisition, and option forwarding
- Update README with Redis store section, updated comparison table, and purge note

## Test plan

- [x] `pnpm test` — all 117 tests pass (13 new Redis store tests)
- [x] `pnpm lint` — no Biome errors
- [x] `pnpm typecheck` — no type errors
- [x] CI passes (Node 20, 22, 24 matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)