### PR TITLE
docs: add community health files

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [paveg]

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug Report
+description: Report a bug in hono-idempotency
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug. Please fill in the details below.
+  - type: input
+    id: version
+    attributes:
+      label: Package Version
+      description: Which version of hono-idempotency are you using?
+      placeholder: "0.6.0"
+    validations:
+      required: true
+  - type: input
+    id: hono-version
+    attributes:
+      label: Hono Version
+      placeholder: "4.7.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: store
+    attributes:
+      label: Store Adapter
+      options:
+        - memory
+        - redis
+        - cloudflare-kv
+        - cloudflare-d1
+        - durable-objects
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: runtime
+    attributes:
+      label: Runtime
+      options:
+        - Node.js
+        - Cloudflare Workers
+        - Deno
+        - Bun
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal code or steps to reproduce the issue.
+      render: typescript
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for your suggestion! Please describe the feature you'd like to see.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How would you like this to work?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or workarounds you've considered.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, code examples, or references.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- What does this PR do? -->
+
+## Related Issues
+
+<!-- e.g. Closes #123 -->
+
+## Checklist
+
+- [ ] Tests added/updated
+- [ ] `pnpm test` passes
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm lint` passes
+- [ ] Changeset added (if user-facing change): `pnpm changeset`

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer at the contact information available on
+[GitHub](https://github.com/paveg).
+
+All complaints will be reviewed and investigated and will result in a response
+that is deemed necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing to hono-idempotency
+
+Thank you for your interest in contributing! This guide will help you get started.
+
+## Development Setup
+
+```bash
+git clone https://github.com/paveg/hono-idempotency.git
+cd hono-idempotency
+pnpm install
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `pnpm test` | Run tests (vitest) |
+| `pnpm test:watch` | Run tests in watch mode |
+| `pnpm build` | Build ESM + CJS (tsup) |
+| `pnpm lint` | Check linting (Biome) |
+| `pnpm lint:fix` | Auto-fix lint issues |
+| `pnpm format` | Format code |
+| `pnpm typecheck` | Type check (tsc --noEmit) |
+
+## Workflow
+
+1. Fork the repository and create a branch from `main`.
+2. Write tests first, then implement your changes (TDD).
+3. Run `pnpm test` and `pnpm typecheck` to verify.
+4. Run `pnpm lint` — a pre-commit hook runs Biome automatically.
+5. Open a pull request against `main`.
+
+## Code Style
+
+- **Formatter/Linter**: Biome (tabs, double quotes, semicolons, 100-char line width)
+- **Tests**: vitest with 100% coverage target (v8 provider)
+- **Comments**: English only; write "why", not "what"
+
+## Adding a Store Adapter
+
+Store adapters implement the `IdempotencyStore` interface (`get`, `lock`, `complete`, `delete`, `purge`). If you want to add a new store:
+
+1. Create `src/stores/<name>.ts` implementing the interface.
+2. Add tests in `tests/stores/<name>.test.ts`.
+3. Export from `package.json` `exports` field.
+4. Document the store in `README.md`.
+
+## Commit Messages
+
+Keep commit messages concise and descriptive. Use [Changesets](https://github.com/changesets/changesets) for versioning:
+
+```bash
+pnpm changeset
+```
+
+## Reporting Issues
+
+Use [GitHub Issues](https://github.com/paveg/hono-idempotency/issues). For security vulnerabilities, see [SECURITY.md](./SECURITY.md).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](./LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.6.x | Yes |
+| < 0.6 | No |
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for security vulnerabilities.**
+
+Please report security issues via [GitHub Security Advisories](https://github.com/paveg/hono-idempotency/security/advisories/new).
+
+Include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+You can expect an initial response within 72 hours. We will work with you to understand and address the issue before any public disclosure.
+
+## Scope
+
+This policy covers the `hono-idempotency` npm package. Vulnerabilities in dependencies should be reported to the respective maintainers.


### PR DESCRIPTION
## Summary

- Add **CONTRIBUTING.md** with development setup, TDD workflow, store adapter guide
- Add **SECURITY.md** pointing to GitHub Security Advisories for vulnerability reports
- Add **CODE_OF_CONDUCT.md** (Contributor Covenant v2.1)
- Add **GitHub Issue Templates** (bug report with store/runtime dropdowns, feature request)
- Add **PR Template** with test/lint/changeset checklist
- Add **FUNDING.yml** for GitHub Sponsors

## Test plan

- [x] Verify GitHub Community Standards page recognizes all files
- [x] Open "New Issue" and confirm both templates render correctly
- [x] Open a draft PR and confirm the PR template loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)