### PR TITLE
ci: add gate job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,11 @@ jobs:
       - run: pnpm vitest run --coverage
 
       - run: pnpm build
+
+  ci-pass:
+    if: always()
+    needs: ci
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+        if: needs.ci.result != 'success'


### PR DESCRIPTION
## Summary

- Add `ci-pass` gate job that depends on all matrix CI jobs
- Provides a single stable status check name for the branch protection ruleset
- Uses `if: always()` to ensure the gate job runs even when matrix jobs fail

## Context

Branch ruleset `Protect main` now requires `ci-pass` to pass before merging to main.

## Test plan

- [x] Verify `ci-pass` job appears in PR checks
- [x] Verify `ci-pass` fails if any matrix job fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)