### PR TITLE
test: fix compat caching test with spy

### DIFF
--- a/tests/compat.test.ts
+++ b/tests/compat.test.ts
@@ -30,13 +30,16 @@ describe("getHonoProblemDetails", () => {
 	});
 
 	it("caches null when module is not available", async () => {
-		vi.doMock("hono-problem-details", () => {
+		const factory = vi.fn(() => {
 			throw new Error("Cannot find module 'hono-problem-details'");
 		});
+		vi.doMock("hono-problem-details", factory);
 		const { getHonoProblemDetails } = await import("../src/compat.js");
 		await getHonoProblemDetails();
 		const second = await getHonoProblemDetails();
 		expect(second).toBeNull();
+		// import() must be attempted only once — second call uses cached null
+		expect(factory).toHaveBeenCalledTimes(1);
 	});
 });
 


### PR DESCRIPTION
## Summary
- Add `vi.fn()` spy to "caches null" test
- Assert factory is called exactly once (proves caching works)
- Previous test would pass even if caching logic was removed

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)