### PR TITLE
perf: hoist TextEncoder and use hex lookup table in fingerprint

### DIFF
--- a/benchmarks/fingerprint.bench.ts
+++ b/benchmarks/fingerprint.bench.ts
@@ -1,0 +1,18 @@
+import { bench, describe } from "vitest";
+import { generateFingerprint } from "../src/fingerprint.js";
+
+describe("generateFingerprint", () => {
+	bench("short body", async () => {
+		await generateFingerprint("POST", "/api/orders", '{"item":"widget"}');
+	});
+
+	bench("medium body (1KB)", async () => {
+		const body = JSON.stringify({ data: "x".repeat(1000) });
+		await generateFingerprint("POST", "/api/orders", body);
+	});
+
+	bench("large body (10KB)", async () => {
+		const body = JSON.stringify({ data: "x".repeat(10000) });
+		await generateFingerprint("POST", "/api/orders", body);
+	});
+});

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -1,13 +1,17 @@
+const encoder = new TextEncoder();
+const HEX_TABLE = Array.from({ length: 256 }, (_, i) => i.toString(16).padStart(2, "0"));
+
 export async function generateFingerprint(
 	method: string,
 	path: string,
 	body: string,
 ): Promise<string> {
 	const data = `${method}:${path}:${body}`;
-	const encoded = new TextEncoder().encode(data);
-	const hashBuffer = await crypto.subtle.digest("SHA-256", encoded);
-	const hashArray = new Uint8Array(hashBuffer);
-	return Array.from(hashArray)
-		.map((b) => b.toString(16).padStart(2, "0"))
-		.join("");
+	const hashBuffer = await crypto.subtle.digest("SHA-256", encoder.encode(data));
+	const bytes = new Uint8Array(hashBuffer);
+	let hex = "";
+	for (let i = 0; i < bytes.length; i++) {
+		hex += HEX_TABLE[bytes[i]];
+	}
+	return hex;
 }


### PR DESCRIPTION
## Summary
- Hoist `TextEncoder` to module-level singleton (avoids object allocation per call)
- Pre-compute 256-entry hex lookup table for O(1) byte-to-hex conversion (replaces `Array.from().map().join()`)

Closes #77

## Benchmark Results

### Before
| Body Size | ops/s |
|-----------|-------|
| Short | 91,181 |
| 1KB | 77,181 |
| 10KB | 38,285 |

### After
| Body Size | ops/s | Speedup |
|-----------|-------|---------|
| Short | 121,735 | **1.34x** |
| 1KB | 86,634 | **1.12x** |
| 10KB | 40,540 | **1.06x** |

The speedup is most pronounced on short bodies because `crypto.subtle.digest` dominates for large payloads.

## Test plan
- [x] All 153 tests pass
- [x] 100% coverage maintained
- [x] Lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)