### PR TITLE
fix: add maxBodySize option to prevent DoS

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,7 @@
 export type IdempotencyErrorCode =
 	| "MISSING_KEY"
 	| "KEY_TOO_LONG"
+	| "BODY_TOO_LARGE"
 	| "FINGERPRINT_MISMATCH"
 	| "CONFLICT";
 
@@ -45,6 +46,16 @@ export const IdempotencyErrors = {
 			status: 400,
 			detail: `Idempotency-Key must be at most ${maxLength} characters`,
 			code: "KEY_TOO_LONG",
+		};
+	},
+
+	bodyTooLarge(maxSize: number): ProblemDetail {
+		return {
+			type: `${BASE_URL}/body-too-large`,
+			title: "Request body is too large",
+			status: 413,
+			detail: `Request body must be at most ${maxSize} bytes`,
+			code: "BODY_TOO_LARGE",
 		};
 	},
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -20,6 +20,7 @@ export function idempotency(options: IdempotencyOptions) {
 		skipRequest,
 		onError,
 		cacheKeyPrefix,
+		maxBodySize,
 		onCacheHit,
 		onCacheMiss,
 	} = options;
@@ -67,6 +68,13 @@ export function idempotency(options: IdempotencyOptions) {
 
 		if (key.length > maxKeyLength) {
 			return errorResponse(IdempotencyErrors.keyTooLong(maxKeyLength));
+		}
+
+		if (maxBodySize != null) {
+			const cl = c.req.header("Content-Length");
+			if (cl && Number.parseInt(cl, 10) > maxBodySize) {
+				return errorResponse(IdempotencyErrors.bodyTooLarge(maxBodySize));
+			}
 		}
 
 		const body = await c.req.text();

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,8 @@ export interface IdempotencyOptions {
 	required?: boolean;
 	methods?: string[];
 	maxKeyLength?: number;
+	/** Maximum request body size in bytes. Checked via Content-Length header before reading the body. */
+	maxBodySize?: number;
 	/** Should be a lightweight, side-effect-free predicate. Avoid reading the request body. */
 	skipRequest?: (c: Context) => boolean | Promise<boolean>;
 	/** Return a Response with an error status (4xx/5xx). Returning 2xx bypasses idempotency guarantees. */


### PR DESCRIPTION
## Summary
- Add `maxBodySize` option to prevent memory exhaustion from large request bodies
- Check `Content-Length` header before `c.req.text()` reads the full body
- Return `413 Payload Too Large` with `BODY_TOO_LARGE` error code when exceeded
- No limit by default (opt-in) for backwards compatibility

## Changes
- `src/middleware.ts`: Content-Length check before body read
- `src/errors.ts`: Add `BODY_TOO_LARGE` error code and `bodyTooLarge()` factory
- `src/types.ts`: Add `maxBodySize?: number` to `IdempotencyOptions`
- `tests/middleware.test.ts`: 4 new tests for maxBodySize behavior

Closes #79

## Test plan
- [x] Rejects request when Content-Length exceeds maxBodySize (413)
- [x] Allows request within limit
- [x] Defaults to no limit when not set
- [x] Skips check when Content-Length header is missing
- [x] All 157 tests pass
- [x] Lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)