### PR TITLE
chore: add changeset for release + update hono-problem-details to 0.1.2

### DIFF
--- a/.changeset/max-body-size.md
+++ b/.changeset/max-body-size.md
@@ -1,0 +1,5 @@
+---
+"hono-idempotency": patch
+---
+
+Add maxBodySize option to prevent DoS via large request bodies

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
 		"@changesets/cli": "2.29.8",
 		"@vitest/coverage-v8": "3.2.4",
 		"hono": "^4.7.0",
-		"hono-problem-details": "0.1.1",
+		"hono-problem-details": "0.1.2",
 		"lefthook": "2.1.1",
 		"tsup": "^8.0.0",
 		"typescript": "^5.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^4.7.0
         version: 4.12.0
       hono-problem-details:
-        specifier: 0.1.1
-        version: 0.1.1(hono@4.12.0)
+        specifier: 0.1.2
+        version: 0.1.2(hono@4.12.0)
       lefthook:
         specifier: 2.1.1
         version: 2.1.1
@@ -805,8 +805,8 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  hono-problem-details@0.1.1:
-    resolution: {integrity: sha512-cGeoDvGjxLGrG1E095T5fcsFVghYfuOsPinIb3p2QlfYNuZ+w4zWzJcNgM7BoVgEhPCbmYXVXBEZ4cPD34yXPg==}
+  hono-problem-details@0.1.2:
+    resolution: {integrity: sha512-Rbr6/uWU8WhSzXrjO7LugpUCLEqxCAiPS5kEJQRY91Z/Vt6lLhN6QLvotkewJUq9ipiSk3YZ7eGzwFTeJA2rlw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@hono/standard-validator': '*'
@@ -2181,7 +2181,7 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  hono-problem-details@0.1.1(hono@4.12.0):
+  hono-problem-details@0.1.2(hono@4.12.0):
     dependencies:
       hono: 4.12.0
 


### PR DESCRIPTION
## Summary
- Add changeset for v0.7.1 release (maxBodySize security patch)
- Update `hono-problem-details` devDependency from 0.1.1 to 0.1.2

## Test plan
- [x] Existing tests pass
- [x] Dependency version updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)