### PR TITLE
chore: add changeset for 0.8.4 patch release

### DIFF
--- a/.changeset/patch-release-0-8-4.md
+++ b/.changeset/patch-release-0-8-4.md
@@ -1,0 +1,5 @@
+---
+"hono-idempotency": patch
+---
+
+Bump development dependencies to resolve Dependabot alerts (vite 7.3.2, rollup 4.60.1, picomatch 2.3.2/4.0.4, minimatch 9.0.9, hono 4.12.14). Only devDependencies are affected; published runtime code is unchanged.


### PR DESCRIPTION
## Summary

- Adds a `patch` changeset to publish 0.8.4 with the devDep bumps merged in #122
- Only devDependencies changed; runtime behavior is identical to 0.8.3
- Merging this PR will trigger the changesets bot to open a Version Packages PR for 0.8.4

## Test plan

- [ ] CI green (no code changed, but keeps the safety net)
- [ ] Merge Version Packages PR once the bot opens it