### PR TITLE
chore: add funding field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
 		"url": "https://github.com/paveg/hono-idempotency/issues"
 	},
 	"license": "MIT",
+	"funding": "https://github.com/sponsors/paveg",
 	"publishConfig": {
 		"access": "public",
 		"provenance": true


### PR DESCRIPTION
## Summary

- Adds `"funding": "https://github.com/sponsors/paveg"` to `package.json`
- Surfaces the sponsor link on the npm package page and in `npm fund` output for consumers
- Matches the convention already set in [hono-problem-details#93](https://github.com/paveg/hono-problem-details/pull/93)

Metadata-only change, no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)