### PR TITLE
feat: warn when cacheKeyPrefix is unset for multi-tenant safety (#126)

### DIFF
--- a/.changeset/dangerously-allow-global-keys.md
+++ b/.changeset/dangerously-allow-global-keys.md
@@ -1,0 +1,9 @@
+---
+"hono-idempotency": minor
+---
+
+Add multi-tenant safety warning. When `cacheKeyPrefix` is not configured and `methods` includes a state-mutating verb (POST/PATCH/PUT/DELETE), the middleware now emits a one-time `console.warn` at factory construction time pointing to the recommended fix.
+
+Set the new `dangerouslyAllowGlobalKeys: true` option to acknowledge a single-tenant deployment and silence the warning. Existing behaviour is unchanged for users who already set `cacheKeyPrefix`.
+
+Closes #126.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -21,8 +21,26 @@ const EXCLUDED_STORE_HEADERS = new Set(["set-cookie", "content-length", "transfe
 const DEFAULT_RETRY_AFTER = "1";
 const REPLAY_HEADER = "Idempotency-Replayed";
 const encoder = new TextEncoder();
+const MUTATING_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
+
+const GLOBAL_KEYS_WARNING = `[hono-idempotency] WARNING: cacheKeyPrefix is not configured.
+  Two users sending the same Idempotency-Key will replay each other's cached responses (cross-tenant data leak).
+  Fix:
+    cacheKeyPrefix: (c) => \`\${c.get("user")?.id ?? "anon"}:\`
+  Single-tenant? Set dangerouslyAllowGlobalKeys: true to silence.
+  Docs: https://github.com/paveg/hono-idempotency#cachekeyprefix`;
+
+function shouldWarnGlobalKeys(options: IdempotencyOptions): boolean {
+	if (options.dangerouslyAllowGlobalKeys === true) return false;
+	if (options.cacheKeyPrefix !== undefined) return false;
+	const methods = options.methods ?? DEFAULT_METHODS;
+	return methods.some((m) => MUTATING_METHODS.has(m.toUpperCase()));
+}
 
 export function idempotency(options: IdempotencyOptions) {
+	if (shouldWarnGlobalKeys(options)) {
+		console.warn(GLOBAL_KEYS_WARNING);
+	}
 	const {
 		store,
 		headerName = "Idempotency-Key",

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,4 +56,15 @@ export interface IdempotencyOptions {
 	 * Errors are swallowed — hooks must not affect request processing.
 	 */
 	onCacheMiss?: (key: string, c: Context) => void | Promise<void>;
+	/**
+	 * Opt out of the multi-tenant safety warning.
+	 *
+	 * When `cacheKeyPrefix` is not set and `methods` includes any state-mutating
+	 * method (POST/PATCH/PUT/DELETE), the middleware emits a one-time
+	 * `console.warn` at factory construction time. Set this to `true` to
+	 * acknowledge that the deployment is single-tenant and silence the warning.
+	 *
+	 * @default false
+	 */
+	dangerouslyAllowGlobalKeys?: boolean;
 }

--- a/tests/compat.test.ts
+++ b/tests/compat.test.ts
@@ -55,7 +55,10 @@ describe("middleware fallback when hono-problem-details is unavailable", () => {
 		const { idempotency } = await import("../src/middleware.js");
 		const { memoryStore } = await import("../src/stores/memory.js");
 		const app = new Hono();
-		app.use("/api/*", idempotency({ store: memoryStore(), required: true }));
+		app.use(
+			"/api/*",
+			idempotency({ store: memoryStore(), required: true, dangerouslyAllowGlobalKeys: true }),
+		);
 		app.post("/api/test", (c) => c.json({ ok: true }));
 
 		const res = await app.request("/api/test", { method: "POST" });

--- a/tests/middleware-warning.test.ts
+++ b/tests/middleware-warning.test.ts
@@ -21,4 +21,40 @@ describe("idempotency() factory-time warning", () => {
 		expect(message).toContain("dangerouslyAllowGlobalKeys: true");
 		expect(message).toContain("https://github.com/paveg/hono-idempotency#cachekeyprefix");
 	});
+
+	it("does not warn when cacheKeyPrefix is a static string", () => {
+		idempotency({ store: memoryStore(), cacheKeyPrefix: "tenant" });
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it("does not warn when cacheKeyPrefix is a function", () => {
+		idempotency({ store: memoryStore(), cacheKeyPrefix: () => "tenant:" });
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it("does not warn when cacheKeyPrefix is an empty string (treated as set)", () => {
+		idempotency({ store: memoryStore(), cacheKeyPrefix: "" });
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it("does not warn when dangerouslyAllowGlobalKeys is true", () => {
+		idempotency({ store: memoryStore(), dangerouslyAllowGlobalKeys: true });
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it("does not warn when methods contain no mutating verbs", () => {
+		idempotency({ store: memoryStore(), methods: ["GET"] });
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it("warns once per factory call (no module-level dedup)", () => {
+		idempotency({ store: memoryStore(), methods: ["POST"] });
+		idempotency({ store: memoryStore(), methods: ["POST"] });
+		expect(warnSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("normalizes method casing when checking for mutating verbs", () => {
+		idempotency({ store: memoryStore(), methods: ["post"] });
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+	});
 });

--- a/tests/middleware-warning.test.ts
+++ b/tests/middleware-warning.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { idempotency } from "../src/middleware.js";
+import { memoryStore } from "../src/stores/memory.js";
+
+describe("idempotency() factory-time warning", () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		warnSpy.mockRestore();
+	});
+
+	it("warns when cacheKeyPrefix is unset and methods include POST/PATCH (defaults)", () => {
+		idempotency({ store: memoryStore() });
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		const message = warnSpy.mock.calls[0]?.[0];
+		expect(message).toContain("[hono-idempotency] WARNING: cacheKeyPrefix is not configured.");
+		expect(message).toContain("dangerouslyAllowGlobalKeys: true");
+		expect(message).toContain("https://github.com/paveg/hono-idempotency#cachekeyprefix");
+	});
+});

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -7,7 +7,7 @@ function createApp(options: Parameters<typeof idempotency>[0] = {}) {
 	const store = options.store ?? memoryStore();
 	const app = new Hono();
 
-	app.use("/api/*", idempotency({ store, ...options }));
+	app.use("/api/*", idempotency({ dangerouslyAllowGlobalKeys: true, store, ...options }));
 
 	app.post("/api/text", (c) => c.text("hello"));
 	app.post("/api/json", (c) => c.json({ message: "ok" }));
@@ -160,7 +160,7 @@ describe("idempotency middleware", () => {
 	it("returns 409 when store.get() finds a processing record", async () => {
 		const store = memoryStore();
 		const app = new Hono();
-		app.use("/api/*", idempotency({ store }));
+		app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true }));
 		app.post("/api/data", (c) => c.text("ok"));
 
 		// Manually insert a processing record into the store
@@ -231,7 +231,7 @@ describe("idempotency middleware", () => {
 	it("deletes key on handler error, allowing retry", async () => {
 		const store = memoryStore();
 		const app = new Hono();
-		app.use("/api/*", idempotency({ store }));
+		app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true }));
 		app.post("/api/error", () => {
 			throw new Error("boom");
 		});
@@ -256,7 +256,7 @@ describe("idempotency middleware", () => {
 	it("deletes key on non-2xx response, allowing retry", async () => {
 		const store = memoryStore();
 		const app = new Hono();
-		app.use("/api/*", idempotency({ store }));
+		app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true }));
 		app.post("/api/server-error", (c) => c.json({ error: "fail" }, 500));
 
 		const key = "key-500";
@@ -366,7 +366,7 @@ describe("idempotency middleware", () => {
 	it("exposes idempotency key via c.get('idempotencyKey')", async () => {
 		const store = memoryStore();
 		const app = new Hono();
-		app.use("/api/*", idempotency({ store }));
+		app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true }));
 		app.post("/api/context-check", (c) => {
 			const idemKey = c.get("idempotencyKey");
 			return c.json({ key: idemKey });
@@ -519,6 +519,7 @@ describe("idempotency middleware", () => {
 			"/api/*",
 			idempotency({
 				store,
+				dangerouslyAllowGlobalKeys: true,
 				// Only use method + path, ignore body
 				fingerprint: (c) => `${c.req.method}:${c.req.path}`,
 			}),
@@ -572,7 +573,7 @@ describe("idempotency middleware", () => {
 		};
 
 		const app = new Hono();
-		app.use("/api/*", idempotency({ store: racyStore }));
+		app.use("/api/*", idempotency({ store: racyStore, dangerouslyAllowGlobalKeys: true }));
 		app.post("/api/race", (c) => c.json({ ok: true }));
 
 		const res = await app.request("/api/race", {
@@ -590,7 +591,7 @@ describe("idempotency middleware", () => {
 	it("catch block deletes key when handler throws non-Error value", async () => {
 		const store = memoryStore();
 		const app = new Hono();
-		app.use("/api/*", idempotency({ store }));
+		app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true }));
 		app.post("/api/throw-string", () => {
 			throw "non-error value";
 		});
@@ -621,6 +622,7 @@ describe("idempotency middleware", () => {
 				"/api/*",
 				idempotency({
 					store,
+					dangerouslyAllowGlobalKeys: true,
 					skipRequest: (c) => c.req.path === "/api/health",
 				}),
 			);
@@ -675,6 +677,7 @@ describe("idempotency middleware", () => {
 				"/api/*",
 				idempotency({
 					store,
+					dangerouslyAllowGlobalKeys: true,
 					skipRequest: async () => {
 						await new Promise((r) => setTimeout(r, 1));
 						return true;
@@ -854,6 +857,7 @@ describe("idempotency middleware", () => {
 				"/api/*",
 				idempotency({
 					store,
+					dangerouslyAllowGlobalKeys: true,
 					required: true,
 					maxKeyLength: 10,
 					onError: (error) => {
@@ -911,6 +915,7 @@ describe("idempotency middleware", () => {
 				"/api/*",
 				idempotency({
 					store,
+					dangerouslyAllowGlobalKeys: true,
 					required: true,
 					onError: (_error, c) =>
 						new Response(JSON.stringify({ path: c.req.path, method: c.req.method }), {
@@ -1069,6 +1074,7 @@ describe("idempotency middleware", () => {
 				"/api/*",
 				idempotency({
 					store,
+					dangerouslyAllowGlobalKeys: true,
 					onCacheHit: (_key, c) => {
 						hitPath = c.req.path;
 					},
@@ -1124,7 +1130,14 @@ describe("idempotency middleware", () => {
 			const store = memoryStore();
 			const app = new Hono();
 			let callCount = 0;
-			app.use("/api/*", idempotency({ store, onCacheMiss: (key) => misses.push(key) }));
+			app.use(
+				"/api/*",
+				idempotency({
+					store,
+					dangerouslyAllowGlobalKeys: true,
+					onCacheMiss: (key) => misses.push(key),
+				}),
+			);
 			app.post("/api/flaky", (c) => {
 				callCount++;
 				return callCount === 1 ? c.json({ error: "fail" }, 500) : c.json({ ok: true });
@@ -1211,6 +1224,7 @@ describe("idempotency middleware", () => {
 				idempotency({
 					store,
 					cacheKeyPrefix: (c) => c.req.header("X-Tenant-Id") ?? "default",
+					// cacheKeyPrefix is set, so no warning needed here
 				}),
 			);
 			app.post("/api/data", (c) => {
@@ -1248,7 +1262,7 @@ describe("idempotency middleware", () => {
 	it("does not replay Set-Cookie header from cached response", async () => {
 		const store = memoryStore();
 		const app = new Hono();
-		app.use("/api/*", idempotency({ store }));
+		app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true }));
 		app.post("/api/with-cookie", (c) => {
 			return new Response("ok", {
 				status: 200,
@@ -1302,7 +1316,10 @@ describe("idempotency middleware", () => {
 			let callCount = 0;
 			const store = memoryStore();
 			const app = new Hono();
-			app.use("/api/*", idempotency({ store, headerName: "X-Request-Id" }));
+			app.use(
+				"/api/*",
+				idempotency({ store, dangerouslyAllowGlobalKeys: true, headerName: "X-Request-Id" }),
+			);
 			app.post("/api/counter", (c) => {
 				callCount++;
 				return c.json({ count: callCount });
@@ -1399,7 +1416,7 @@ describe("idempotency middleware", () => {
 			let callCount = 0;
 			const store = memoryStore();
 			const app = new Hono();
-			app.use("/api/*", idempotency({ store, methods: [] }));
+			app.use("/api/*", idempotency({ store, methods: [] })); // no mutating methods → no warning
 			app.post("/api/counter", (c) => {
 				callCount++;
 				return c.json({ count: callCount });
@@ -1420,7 +1437,7 @@ describe("idempotency middleware", () => {
 		it("custom methods: ['PUT'] applies idempotency to PUT only", async () => {
 			const store = memoryStore();
 			const app = new Hono();
-			app.use("/api/*", idempotency({ store, methods: ["PUT"] }));
+			app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true, methods: ["PUT"] }));
 			app.put("/api/resource", (c) => c.json({ updated: true }));
 			app.post("/api/resource", (c) => c.json({ created: true }));
 
@@ -1442,7 +1459,10 @@ describe("idempotency middleware", () => {
 			// POST is not in methods list — passes through without idempotency
 			let postCount = 0;
 			const app2 = new Hono();
-			app2.use("/api/*", idempotency({ store: memoryStore(), methods: ["PUT"] }));
+			app2.use(
+				"/api/*",
+				idempotency({ store: memoryStore(), dangerouslyAllowGlobalKeys: true, methods: ["PUT"] }),
+			);
 			app2.post("/api/resource", (c) => {
 				postCount++;
 				return c.json({ count: postCount });
@@ -1464,7 +1484,7 @@ describe("idempotency middleware", () => {
 		it("status 299 is cached (res.ok = true)", async () => {
 			const store = memoryStore();
 			const app = new Hono();
-			app.use("/api/*", idempotency({ store }));
+			app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true }));
 			app.post("/api/status-299", (c) => new Response("edge", { status: 299 }));
 
 			const key = "key-299";
@@ -1482,7 +1502,7 @@ describe("idempotency middleware", () => {
 		it("status 300 is not cached (res.ok = false)", async () => {
 			const store = memoryStore();
 			const app = new Hono();
-			app.use("/api/*", idempotency({ store }));
+			app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true }));
 			app.post(
 				"/api/status-300",
 				(c) => new Response(null, { status: 300, headers: { Location: "/other" } }),
@@ -1502,7 +1522,7 @@ describe("idempotency middleware", () => {
 		it("status 200 is cached (lower bound)", async () => {
 			const store = memoryStore();
 			const app = new Hono();
-			app.use("/api/*", idempotency({ store }));
+			app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true }));
 			app.post("/api/ok", (c) => c.text("ok"));
 
 			const key = "key-200";
@@ -1519,7 +1539,7 @@ describe("idempotency middleware", () => {
 		it("status 400 is not cached (client error)", async () => {
 			const store = memoryStore();
 			const app = new Hono();
-			app.use("/api/*", idempotency({ store }));
+			app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true }));
 			app.post("/api/status-400", () => new Response("bad request", { status: 400 }));
 
 			const key = "key-400";
@@ -1555,7 +1575,10 @@ describe("idempotency middleware", () => {
 		const store = memoryStore();
 		const fixedFp = "fixed-fingerprint";
 		const app = new Hono();
-		app.use("/api/*", idempotency({ store, fingerprint: () => fixedFp }));
+		app.use(
+			"/api/*",
+			idempotency({ store, dangerouslyAllowGlobalKeys: true, fingerprint: () => fixedFp }),
+		);
 		app.post("/api/text", (c) => c.text("hello"));
 
 		const key = "key-no-response";
@@ -1623,7 +1646,7 @@ describe("idempotency middleware", () => {
 		it("rejects request when Content-Length exceeds maxBodySize", async () => {
 			const store = memoryStore();
 			const app = new Hono();
-			app.use("/api/*", idempotency({ store, maxBodySize: 100 }));
+			app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true, maxBodySize: 100 }));
 			app.post("/api/text", (c) => c.text("ok"));
 
 			const res = await app.request("/api/text", {
@@ -1642,7 +1665,7 @@ describe("idempotency middleware", () => {
 		it("allows request when Content-Length is within maxBodySize", async () => {
 			const store = memoryStore();
 			const app = new Hono();
-			app.use("/api/*", idempotency({ store, maxBodySize: 100 }));
+			app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true, maxBodySize: 100 }));
 			app.post("/api/text", (c) => c.text("ok"));
 
 			const res = await app.request("/api/text", {
@@ -1672,7 +1695,7 @@ describe("idempotency middleware", () => {
 		it("rejects large body even when Content-Length header is missing", async () => {
 			const store = memoryStore();
 			const app = new Hono();
-			app.use("/api/*", idempotency({ store, maxBodySize: 100 }));
+			app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true, maxBodySize: 100 }));
 			app.post("/api/text", (c) => c.text("ok"));
 
 			const res = await app.request("/api/text", {
@@ -1688,7 +1711,7 @@ describe("idempotency middleware", () => {
 		it("allows small body when Content-Length header is missing", async () => {
 			const store = memoryStore();
 			const app = new Hono();
-			app.use("/api/*", idempotency({ store, maxBodySize: 100 }));
+			app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true, maxBodySize: 100 }));
 			app.post("/api/text", (c) => c.text("ok"));
 
 			const res = await app.request("/api/text", {
@@ -1702,7 +1725,7 @@ describe("idempotency middleware", () => {
 		it("maxBodySize: 0 with empty body passes (0 is NOT > 0)", async () => {
 			const store = memoryStore();
 			const app = new Hono();
-			app.use("/api/*", idempotency({ store, maxBodySize: 0 }));
+			app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true, maxBodySize: 0 }));
 			app.post("/api/text", (c) => c.text("ok"));
 
 			const res = await app.request("/api/text", {
@@ -1718,7 +1741,7 @@ describe("idempotency middleware", () => {
 		it("maxBodySize: 0 rejects any non-empty body", async () => {
 			const store = memoryStore();
 			const app = new Hono();
-			app.use("/api/*", idempotency({ store, maxBodySize: 0 }));
+			app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true, maxBodySize: 0 }));
 			app.post("/api/text", (c) => c.text("ok"));
 
 			const res = await app.request("/api/text", {
@@ -1737,7 +1760,7 @@ describe("idempotency middleware", () => {
 		it("rejects request when Content-Length is negative", async () => {
 			const store = memoryStore();
 			const app = new Hono();
-			app.use("/api/*", idempotency({ store, maxBodySize: 100 }));
+			app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true, maxBodySize: 100 }));
 			app.post("/api/text", (c) => c.text("ok"));
 
 			const res = await app.request("/api/text", {
@@ -1755,7 +1778,7 @@ describe("idempotency middleware", () => {
 		it("rejects oversized body on second request with existing completed record", async () => {
 			const store = memoryStore();
 			const app = new Hono();
-			app.use("/api/*", idempotency({ store, maxBodySize: 50 }));
+			app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true, maxBodySize: 50 }));
 			app.post("/api/data", (c) => c.text("ok"));
 
 			// First request succeeds with small body
@@ -1808,7 +1831,10 @@ describe("idempotency middleware", () => {
 		};
 
 		const app = new Hono();
-		app.use("/api/*", idempotency({ store, fingerprint: () => "fixed-fp" }));
+		app.use(
+			"/api/*",
+			idempotency({ store, dangerouslyAllowGlobalKeys: true, fingerprint: () => "fixed-fp" }),
+		);
 		app.post("/api/text", (c) => c.text("ok"));
 
 		const res = await app.request("/api/text", {
@@ -1826,7 +1852,7 @@ describe("idempotency middleware", () => {
 		let callCount = 0;
 		const store = memoryStore();
 		const app = new Hono();
-		app.use("/api/*", idempotency({ store }));
+		app.use("/api/*", idempotency({ store, dangerouslyAllowGlobalKeys: true }));
 		app.post("/api/flaky", (c) => {
 			callCount++;
 			if (callCount === 1) {


### PR DESCRIPTION
## Summary

Closes #126.

An internal pentest of a Hono + Better-Auth + Cloudflare Workers SaaS surfaced a HIGH-severity cross-tenant cache replay: User B sending the same `Idempotency-Key` as User A received User A's cached response. The root cause was `idempotency({ store })` registered without `cacheKeyPrefix`. The library API has supported per-tenant scoping all along — the gap was **discoverability**, not capability.

This PR makes the misconfiguration fail-loud at the developer's first run by emitting a one-time `console.warn` at factory-construction time, plus an explicit opt-out (`dangerouslyAllowGlobalKeys: true`) for genuine single-tenant deployments.

## What changes

- New option `dangerouslyAllowGlobalKeys?: boolean` on `IdempotencyOptions` (defaults to `false`).
- Factory-time `console.warn` fires when **all** of the following hold:
  - `dangerouslyAllowGlobalKeys !== true`, AND
  - `cacheKeyPrefix === undefined` (empty string and function values are both treated as set), AND
  - the effective `methods` array contains at least one of `POST` / `PATCH` / `PUT` / `DELETE` (case-insensitive).
- The warning message is environment-agnostic (no `NODE_ENV` branching), and includes both the recommended fix (with the session-cookie auth pattern: `c.get("user")?.id`) and the docs URL.
- The per-request hot path is untouched — the check runs once per `idempotency({...})` call. No new branches in the dispatch loop.
- `shouldWarnGlobalKeys`, `MUTATING_METHODS`, and the warning string are intentionally **not** exported, so the detection logic can evolve without breaking public API.

```mermaid
flowchart TD
  A[idempotency call] --> B{dangerouslyAllowGlobalKeys = true?}
  B -- yes --> S[silent]
  B -- no --> C{cacheKeyPrefix set?}
  C -- yes --> S
  C -- no --> D{methods contain<br/>POST/PATCH/PUT/DELETE?}
  D -- no --> S
  D -- yes --> W[console.warn once]
  S --> R[return middleware]
  W --> R
```

## Migration

- **No action** for users who already set `cacheKeyPrefix` — behaviour is identical.
- **Multi-tenant deployments** should set `cacheKeyPrefix` (the warning text demonstrates the session-cookie pattern).
- **Genuine single-tenant deployments** can set `dangerouslyAllowGlobalKeys: true` to silence the warning.

Additive and non-breaking. Ships as a `minor` bump via changeset.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm vitest run --coverage` — 214 tests pass (206 baseline + 8 new warning tests), 100% coverage on `src/middleware.ts` and `src/types.ts`
- [x] `pnpm build` — ESM and CJS outputs clean
- [x] Zero `[hono-idempotency] WARNING` lines reach stderr in the test run (`grep -c` confirms `0`)
- [x] Manual sanity-check: a factory call without `cacheKeyPrefix` emits the warning exactly once; with `dangerouslyAllowGlobalKeys: true` it emits nothing

## Out of scope

- README Quick Start security callout and session-cookie example for `cacheKeyPrefix` — sibling PR for issue #126.
- TypeScript compat matrix in CI (mirroring `paveg/hono-problem-details#121`) — separate follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)