### PR TITLE
ci: add TypeScript compat matrix (5.0–6.0) and bump dev TS to 6.0.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,40 @@ jobs:
 
       - run: pnpm build
 
-  ci-pass:
-    if: always()
-    needs: ci
+  type-compat:
     runs-on: ubuntu-latest
+    needs: ci
+    strategy:
+      fail-fast: false
+      matrix:
+        ts: ["5.0.4", "5.4.5", "5.7.3", "5.9.3"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 22
+      - name: Enable corepack
+        run: corepack enable
+      - name: Resolve pnpm store path
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - name: Type-check consumer against TS ${{ matrix.ts }}
+        env:
+          TS_VERSION: ${{ matrix.ts }}
+        run: pnpm dlx --package="typescript@${TS_VERSION}" -c 'tsc -p tsconfig.compat.json'
+
+  ci-pass:
+    runs-on: ubuntu-latest
+    needs: [ci, type-compat]
+    if: always()
     steps:
       - run: exit 1
-        if: needs.ci.result != 'success'
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ts: ["5.0.4", "5.4.5", "5.7.3", "5.9.3"]
+        ts: ["5.0.4", "5.4.5", "5.7.3", "5.9.3", "6.0.3"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ npm install hono-idempotency
 pnpm add hono-idempotency
 ```
 
+### Requirements
+
+- Hono `>= 4.0.0` (peer dependency)
+- TypeScript `>= 5.0` — the published `.d.ts` files are CI-tested against TS 5.0, 5.4, 5.7, and 5.9. Older TS versions may work but are not verified.
+- Node.js `>= 20`
+
 ## Quick Start
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
 		"hono-problem-details": "0.1.4",
 		"lefthook": "2.1.1",
 		"tsup": "^8.5.1",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"vitest": "^3.2.4"
 	},
 	"packageManager": "pnpm@10.14.0",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
 		"lint:fix": "biome check --write .",
 		"format": "biome format --write .",
 		"typecheck": "tsc --noEmit",
+		"test:compat": "tsc -p tsconfig.compat.json",
 		"release": "pnpm build && changeset publish",
 		"version-packages": "changeset version && pnpm lint:fix"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,10 +31,10 @@ importers:
         version: 2.1.1
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.10)(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.4
         version: 3.2.4
@@ -1346,8 +1346,8 @@ packages:
       typescript:
         optional: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2628,7 +2628,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(postcss@8.5.10)(typescript@5.9.3):
+  tsup@8.5.1(postcss@8.5.10)(typescript@6.0.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -2649,14 +2649,14 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.10
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
       - supports-color
       - tsx
       - yaml
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   ufo@1.6.3: {}
 

--- a/tests/type-compat/core-consumer.ts
+++ b/tests/type-compat/core-consumer.ts
@@ -1,0 +1,184 @@
+// Type-compatibility consumer — compiled against multiple TS versions in CI.
+// Never executed; exists purely to exercise every public .d.ts surface.
+import type {
+	D1DatabaseLike,
+	D1PreparedStatementLike,
+	D1StoreOptions,
+	DurableObjectStorageLike,
+	DurableObjectStoreOptions,
+	IdempotencyEnv,
+	IdempotencyErrorCode,
+	IdempotencyOptions,
+	IdempotencyRecord,
+	IdempotencyStore,
+	KVNamespaceLike,
+	KVStoreOptions,
+	MemoryStore,
+	MemoryStoreOptions,
+	ProblemDetail,
+	RedisClientLike,
+	RedisStoreOptions,
+	StoredResponse,
+} from "../../dist/index.js";
+import {
+	IdempotencyErrors,
+	RECORD_STATUS_COMPLETED,
+	RECORD_STATUS_PROCESSING,
+	clampHttpStatus,
+	idempotency,
+	problemResponse,
+} from "../../dist/index.js";
+import { d1Store } from "../../dist/stores/cloudflare-d1.js";
+import { kvStore } from "../../dist/stores/cloudflare-kv.js";
+import { durableObjectStore } from "../../dist/stores/durable-objects.js";
+import { memoryStore } from "../../dist/stores/memory.js";
+import { redisStore } from "../../dist/stores/redis.js";
+
+// --- value exports ---
+
+const _statusCompleted: typeof RECORD_STATUS_COMPLETED = RECORD_STATUS_COMPLETED;
+const _statusProcessing: typeof RECORD_STATUS_PROCESSING = RECORD_STATUS_PROCESSING;
+
+const _clamped: number = clampHttpStatus(200);
+const _clamped2: number = clampHttpStatus(999); // out-of-range → 500
+
+const _problem: ProblemDetail = IdempotencyErrors.missingKey();
+const _problem2: ProblemDetail = IdempotencyErrors.keyTooLong(256);
+const _problem3: ProblemDetail = IdempotencyErrors.bodyTooLarge(1024);
+const _problem4: ProblemDetail = IdempotencyErrors.fingerprintMismatch();
+const _problem5: ProblemDetail = IdempotencyErrors.conflict();
+
+// problemResponse returns Response — avoid annotating the bare type since types:[] excludes DOM
+const _response = problemResponse(_problem);
+const _response2 = problemResponse(_problem, { "X-Custom": "value" });
+
+// --- type annotations ---
+
+const _errorCode: IdempotencyErrorCode = "MISSING_KEY";
+
+const _stored: StoredResponse = {
+	status: 200,
+	headers: { "content-type": "application/json" },
+	body: '{"id":"pay_123"}',
+};
+
+const _record: IdempotencyRecord = {
+	key: "my-key",
+	fingerprint: "abc123",
+	status: "processing",
+	createdAt: Date.now(),
+};
+
+const _recordCompleted: IdempotencyRecord = {
+	key: "my-key",
+	fingerprint: "abc123",
+	status: "completed",
+	response: _stored,
+	createdAt: Date.now(),
+};
+
+// IdempotencyEnv — used as type parameter
+const _envCheck: IdempotencyEnv["Variables"] = { idempotencyKey: "key" };
+const _envCheck2: IdempotencyEnv["Variables"] = { idempotencyKey: undefined };
+
+// --- memoryStore ---
+
+const _memOpts: MemoryStoreOptions = { ttl: 60000, maxSize: 100, sweepInterval: 30000 };
+const _mem: MemoryStore = memoryStore(_memOpts);
+const _memSize: number = _mem.size;
+
+// --- idempotency middleware with memoryStore ---
+
+const _opts: IdempotencyOptions = {
+	store: _mem,
+	cacheKeyPrefix: "tenant-a",
+	required: false,
+	methods: ["POST", "PATCH"],
+	maxKeyLength: 256,
+	maxBodySize: 1024 * 1024,
+};
+const _middleware = idempotency(_opts);
+
+// IdempotencyStore interface
+const _storeRef: IdempotencyStore = _mem;
+
+// --- redisStore ---
+
+const _redisClient: RedisClientLike = {
+	get: async (_key: string) => null,
+	set: async (_key: string, _value: string, _opts?: { NX?: boolean; EX?: number }) => null,
+	del: async (..._keys: string[]) => 0,
+};
+const _redisOpts: RedisStoreOptions = { client: _redisClient, ttl: 86400 };
+const _redis: IdempotencyStore = redisStore(_redisOpts);
+
+// --- kvStore ---
+
+const _kvNamespace: KVNamespaceLike = {
+	get: async (_key: string, _opts: { type: "json" }) => null,
+	put: async (_key: string, _value: string, _opts?: { expirationTtl?: number }) => {},
+	delete: async (_key: string) => {},
+};
+const _kvOpts: KVStoreOptions = { namespace: _kvNamespace, ttl: 86400 };
+const _kv: IdempotencyStore = kvStore(_kvOpts);
+
+// --- d1Store ---
+
+const _d1PreparedStmt: D1PreparedStatementLike = {
+	bind: (..._params: unknown[]) => _d1PreparedStmt,
+	run: async () => ({ success: true, meta: { changes: 1 } }),
+	first: async () => null,
+};
+const _d1Db: D1DatabaseLike = {
+	prepare: (_sql: string) => _d1PreparedStmt,
+};
+const _d1Opts: D1StoreOptions = { database: _d1Db, tableName: "idempotency_keys", ttl: 86400 };
+const _d1: IdempotencyStore = d1Store(_d1Opts);
+
+// --- durableObjectStore ---
+
+const _doStorage: DurableObjectStorageLike = {
+	get: async <T>(_key: string): Promise<T | undefined> => undefined,
+	put: async <T>(_key: string, _value: T): Promise<void> => {},
+	delete: async (_key: string) => true,
+	list: async (_opts?: { prefix?: string }) => new Map<string, unknown>(),
+};
+const _doOpts: DurableObjectStoreOptions = { storage: _doStorage, ttl: 86400000 };
+const _do: IdempotencyStore = durableObjectStore(_doOpts);
+
+void _statusCompleted;
+void _statusProcessing;
+void _clamped;
+void _clamped2;
+void _problem;
+void _problem2;
+void _problem3;
+void _problem4;
+void _problem5;
+void _response;
+void _response2;
+void _errorCode;
+void _stored;
+void _record;
+void _recordCompleted;
+void _envCheck;
+void _envCheck2;
+void _memOpts;
+void _mem;
+void _memSize;
+void _opts;
+void _middleware;
+void _storeRef;
+void _redisClient;
+void _redisOpts;
+void _redis;
+void _kvNamespace;
+void _kvOpts;
+void _kv;
+void _d1PreparedStmt;
+void _d1Db;
+void _d1Opts;
+void _d1;
+void _doStorage;
+void _doOpts;
+void _do;

--- a/tsconfig.compat.json
+++ b/tsconfig.compat.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"lib": ["ES2022"],
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"types": []
+	},
+	"include": ["tests/type-compat/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
 		"sourceMap": true,
 		"outDir": "./dist",
 		"rootDir": "./src",
-		"types": []
+		"types": [],
+		"ignoreDeprecations": "6.0"
 	},
 	"include": ["src"],
 	"exclude": ["node_modules", "dist", "tests"]


### PR DESCRIPTION
## Summary

Establishes the TypeScript supported-range as a tested, machine-verified invariant **and** lifts the dev TS to 6.0.3 in the same change.

Two phases bundled because they are tightly coupled — the matrix is what makes the TS 6 bump verifiable rather than a leap of faith. Mirrors the patterns landed in [`paveg/hono-problem-details#121`](https://github.com/paveg/hono-problem-details/pull/121) (Phase 1) and [`paveg/hono-cf-access#45`](https://github.com/paveg/hono-cf-access/pull/45) (Phase 2), adapted to `hono-idempotency`'s multi-entry-point public API.

## What this guards against

The library is built with a pinned dev TypeScript, but consumers may compile against older TS. If a future build emits `.d.ts` syntax requiring a newer TS than declared, library users on the older TS would see compile errors with no warning at PR time. The matrix detects this at PR time, across the full TS 5.0 → 6.0 range.

## How it works

```mermaid
flowchart LR
  A[ci job<br/>build dist/] --> B[type-compat matrix]
  B --> M1[TS 5.0.4]
  B --> M2[TS 5.4.5]
  B --> M3[TS 5.7.3]
  B --> M4[TS 5.9.3]
  B --> M5[TS 6.0.3]
  M1 & M2 & M3 & M4 & M5 --> P[ci-pass]
```

- `tests/type-compat/core-consumer.ts` exercises the full public API surface: `idempotency`, errors, status helpers, every type export from the main entry, and all 5 store factories (`memoryStore`, `redisStore`, `kvStore`, `d1Store`, `durableObjectStore`) from their respective `hono-idempotency/stores/*` entry points. Imports come from `dist/` — the post-build artifacts users actually receive.
- `tsconfig.compat.json` type-checks `consumer.ts` in isolation with ES2022 + bundler resolution + strict — the typical consumer config. It has no `baseUrl`, so it works on TS 6 unmodified.
- New CI job `type-compat` runs after `ci` (which builds `dist/`) and re-checks `consumer.ts` with each matrix TS version via `pnpm dlx --package=typescript@${TS_VERSION}`.
- `ci-pass` now requires **both** `ci` and `type-compat` to succeed.

## Why the dev TS bump is bundled here

TS 6.0 deprecates `baseUrl` and `tsup@8.5.1`'s DTS bundler hard-codes `baseUrl: "."` in the compiler options it constructs ([tsup#1388](https://github.com/egoist/tsup/issues/1388)). Without an escape hatch, `pnpm build` fails on TS 6 with:

```
error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
  Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

The fix the error message itself prescribes: set `"ignoreDeprecations": "6.0"` in the project `tsconfig.json` and let it propagate into tsup's DTS step. The value is valid only on the TS 6 series — TS 7 will reject it, surfacing the issue at the next TS major and forcing the cleanup.

## Changes

| Change | File | Why |
|---|---|---|
| New `tsconfig.compat.json` | root | Strict ES2022 / bundler / `noEmit` config consuming the consumer file |
| New `tests/type-compat/core-consumer.ts` | tests/ | Touches every public export to exercise the full `dist/*.d.ts` surface |
| Add `test:compat` script | `package.json` | Local convenience: `pnpm test:compat` |
| New `type-compat` matrix job | `.github/workflows/ci.yml` | Runs the consumer compat check on TS `[5.0.4, 5.4.5, 5.7.3, 5.9.3, 6.0.3]` |
| `ci-pass` now `needs: [ci, type-compat]` | `.github/workflows/ci.yml` | Block merges that break either gate |
| `Requirements` section | `README.md` | Documents Hono peer-dep, TS range, and Node range |
| `typescript: ^5.9.3` → `^6.0.3` | `package.json` | Dev TS major bump |
| `"ignoreDeprecations": "6.0"` | `tsconfig.json` | TS-official escape hatch for tsup#1388 |

## What this PR explicitly does NOT change

- **No tsup migration.** Replacing tsup with `tsdown` / `unbuild` / direct `tsc + esbuild` is the long-term fix for the underlying tsup#1388 issue, but is out of scope. `ignoreDeprecations` is a temporary bridge until that landing.
- **No `tsconfig.compat.json` touch under TS 6.** That file has no `baseUrl` and is consumed only via `pnpm dlx --package="typescript@${VERSION}"` against `dist/*.d.ts` after the build — unaffected by tsup's TS 6 deprecation.
- **No README beyond the new Requirements section.** No content reshuffling.

## Test plan

- [x] `pnpm typecheck` — clean on TS 6.0.3
- [x] `pnpm build` — ESM + CJS + DTS clean (DTS step would fail on TS 6 without `ignoreDeprecations`)
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 206/206 pass
- [x] `pnpm test:compat` — clean with locally-pinned TS 6.0.3
- [x] `pnpm dlx --package="typescript@5.0.4" -c 'tsc -p tsconfig.compat.json'` — clean (lower bound)
- [x] `pnpm dlx --package="typescript@6.0.3" -c 'tsc -p tsconfig.compat.json'` — clean (upper bound)
- [ ] CI green: `ci` (Node 20, 22, 24) + `type-compat` (TS 5.0.4 / 5.4.5 / 5.7.3 / 5.9.3 / 6.0.3)

## Removal plan for `ignoreDeprecations`

The escape hatch is intentionally temporary. Two events that should retire it:

1. **tsup releases a fix for #1388** (bundler stops injecting `baseUrl`) — drop the line, no other change needed.
2. **Project migrates off tsup** — drop the line during the build-toolchain swap PR.

When TS 7 ships, the `"6.0"` value stops being valid and CI will surface it as an error on the next TS major bump, forcing the cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
