### PR TITLE
chore: drop Node.js 20 (EOL) and bump min to 22

### DIFF
--- a/.changeset/drop-node-20.md
+++ b/.changeset/drop-node-20.md
@@ -1,0 +1,9 @@
+---
+"hono-idempotency": minor
+---
+
+Drop Node.js 20 support. Minimum supported Node.js version is now 22.
+
+Node.js 20 reached end-of-life on 2026-04-30. CI is now tested on Node 22 and 24 only, and `package.json` declares `engines.node: ">=22"`. The published bundle does not use any 22-only Node APIs, but the supported range now reflects what is actually tested.
+
+Users on Node 20 should upgrade to Node 22 (the current LTS).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ pnpm add hono-idempotency
 ### Requirements
 
 - Hono `>= 4.0.0` (peer dependency)
-- TypeScript `>= 5.0` — the published `.d.ts` files are CI-tested against TS 5.0, 5.4, 5.7, and 5.9. Older TS versions may work but are not verified.
-- Node.js `>= 20`
+- TypeScript `>= 5.0` — the published `.d.ts` files are CI-tested against TS 5.0, 5.4, 5.7, 5.9, and 6.0. Older TS versions may work but are not verified.
+- Node.js `>= 22` — Node.js 20 reached end-of-life on 2026-04-30 and is no longer tested.
 
 ## Quick Start
 

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
 		"provenance": true
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22"
 	},
 	"peerDependencies": {
 		"hono": ">=4.0.0",


### PR DESCRIPTION
## Summary

Node.js 20 reached **end-of-life on 2026-04-30**. This PR removes Node 20 from the CI matrix, bumps `engines.node` to `>=22`, and updates the README accordingly. Also fixes a stale TS list in the README's `Requirements` section that was missing `6.0` (which was added to the matrix in #131 but not reflected in the docs).

## Changes

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | `node-version: [20, 22, 24]` → `[22, 24]` |
| `package.json` | `engines.node: ">=20"` → `">=22"` |
| `README.md` | `Node.js >= 20` → `Node.js >= 22` (with EOL note); TS list 5.0/5.4/5.7/5.9 → 5.0/5.4/5.7/5.9/6.0 |
| `.changeset/drop-node-20.md` | Minor bump describing the dropped support range |

## Why bump `engines.node` instead of leaving it permissive

`engines.node` does not block install by default in npm/pnpm — it only emits a warning. But declaring it explicitly:

1. Aligns the supported range with what is actually CI-tested.
2. Surfaces the unsupported state as an `EBADENGINE` warning at install time, so consumers on Node 20 see the issue immediately rather than at runtime.
3. Avoids "supported by accident" — if a future change happens to require a Node-22-only API, that becomes a documented constraint rather than a silent bug for Node 20 users.

The published bundle does not currently use any Node-22-only APIs, but the supported range now matches the testing surface.

## Versioning

`minor` bump via changeset. Per semver-zero (we are 0.x), minor is the right notch for a soft-breaking change that drops a previously-claimed compatibility tier — there is no major bump available at this stage of the lifecycle. Released CHANGELOG will call out the dropped support clearly.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 214/214 pass
- [x] `pnpm build` — ESM + CJS + DTS clean
- [x] `pnpm changeset status` — confirms minor bump
- [ ] CI green on Node 22 + Node 24 (and the TS compat matrix continues to pass unaffected, since its dedicated job already runs on Node 22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
