### PR TITLE
chore(ci): pin workflow actions to commit SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
       matrix:
         node-version: [22, 24]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4.3.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4.3.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           # Node 24 ships with npm 11.x (required for OIDC Trusted Publishing).
           # Node 22 ships with npm 10.x and self-upgrading via 'npm install -g npm@latest' is unreliable in CI.
@@ -27,7 +27,7 @@ jobs:
           cache: pnpm
           registry-url: "https://registry.npmjs.org"
       - run: pnpm install --frozen-lockfile
-      - uses: changesets/action@v1
+      - uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b  # v1.8.0
         id: changesets
         with:
           publish: pnpm release


### PR DESCRIPTION
## Summary
- Pin all `uses:` refs in .github/workflows/*.yml to full-length commit SHAs
- Add .github/dependabot.yml (github-actions, weekly grouped)

## Why
paveg/gh-infra is rolling out `actions.sha_pinning_required: true` across hono-* OSS repos (see paveg/gh-infra#31). Once that lands, GitHub refuses to dispatch any workflow whose `uses:` is a tag rather than a SHA.

Major versions preserved.

## Test plan
- [ ] CI passes on this PR
- [ ] Dependabot picks up github-actions ecosystem

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added Dependabot configuration to automate GitHub Actions dependency management with weekly updates and grouped versioning for improved maintenance
  * Updated CI and release workflows to pin GitHub Actions to specific commit SHAs instead of floating version tags for enhanced security and build reproducibility

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paveg/hono-idempotency/pull/136)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->