### PR TITLE
chore(deps): group vitest and @vitest/* into one Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,13 @@ updates:
       actions:
         patterns:
           - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"


### PR DESCRIPTION
## Why

`vitest` and `@vitest/coverage-v8` must always share the same major version. Dependabot opened them as **separate PRs** (coverage-v8 is exact-pinned), so a vitest-only bump (#138) shipped a mixed-version pair and crashed the coverage provider in CI:

```
Loaded vitest@4.1.0 and @vitest/coverage-v8@3.2.4.
Running mixed versions is not supported and may lead into bugs
TypeError: Cannot read properties of undefined (reading 'fetchCache')
```

## What

Add an `npm` ecosystem entry with a `vitest` group so `vitest` and every `@vitest/*` package are bumped **together in a single PR**. This is the root-cause fix for the split that broke #138.

```yaml
  - package-ecosystem: "npm"
    directory: "/"
    schedule:
      interval: "weekly"
    groups:
      vitest:
        patterns:
          - "vitest"
          - "@vitest/*"
```

Non-vitest npm dependencies (e.g. `hono`) keep their individual PRs — only the vitest family is grouped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)