### PR TITLE
security: bump hono devDependency to ^4.12.27 (close dev/CI gap)

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
 		"@changesets/changelog-github": "0.5.2",
 		"@changesets/cli": "2.29.8",
 		"@vitest/coverage-v8": "^4.1.8",
-		"hono": "^4.12.14",
+		"hono": "^4.12.27",
 		"hono-problem-details": "0.1.4",
 		"lefthook": "2.1.1",
 		"tsup": "^8.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,11 +21,11 @@ importers:
         specifier: ^4.1.8
         version: 4.1.9(vitest@4.1.9)
       hono:
-        specifier: ^4.12.14
-        version: 4.12.21
+        specifier: ^4.12.27
+        version: 4.12.27
       hono-problem-details:
         specifier: 0.1.4
-        version: 0.1.4(hono@4.12.21)
+        version: 0.1.4(hono@4.12.27)
       lefthook:
         specifier: 2.1.1
         version: 2.1.1
@@ -900,8 +900,8 @@ packages:
       zod:
         optional: true
 
-  hono@4.12.21:
-    resolution: {integrity: sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==}
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -2206,11 +2206,11 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  hono-problem-details@0.1.4(hono@4.12.21):
+  hono-problem-details@0.1.4(hono@4.12.27):
     dependencies:
-      hono: 4.12.21
+      hono: 4.12.27
 
-  hono@4.12.21: {}
+  hono@4.12.27: {}
 
   html-escaper@2.0.2: {}
 


### PR DESCRIPTION
## Security follow-up: close the dev/CI hono gap

The previously merged security PRs raised the `hono` **peerDependency** floor to `>=4.12.25` (protecting consumers), but left the **devDependency** at `^4.12.14`. pnpm kept that resolved to `4.12.21` in the lockfile, so CI was still building and testing against a vulnerable hono.

### Change
- `hono` devDependency: `^4.12.14` → `^4.12.27`
- `pnpm-lock.yaml` regenerated — hono now resolves to **4.12.27** (matches the peerDep floor)

### CVEs now covered in dev/CI (fixed in hono 4.12.25)
| Advisory | Severity | Description |
|---|---|---|
| GHSA-88fw-hqm2-52qc | **High** | CORS reflects any Origin with credentials |
| GHSA-wwfh-h76j-fc44 | Moderate | serve-static path traversal on Windows |
| GHSA-xrhx-7g5j-rcj5 | Moderate | IP Restriction bypass for non-canonical IPv6 |
+ earlier advisories

Verified locally: `pnpm install --frozen-lockfile`, `lint`, `typecheck`, `test`, `build` all pass.

This supersedes the standalone Dependabot `hono` → 4.12.25 PR in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code)_